### PR TITLE
fix(state): valve/pump control, emergency recovery, TSIC glitches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,3 +108,14 @@ Treat layout regressions (cut-off text, overlapping rows, shifting numbers, misa
 ## Regarding Dependencies:
 - Avoid introducing new external dependencies unless absolutely necessary.
 - If a new dependency is required, please state the reason.
+
+## Hardware Control Invariants (CRITICAL)
+
+When modifying state machine states, handlers, or anything touching pump/valve/heater:
+
+1. **Every state that activates pump or valve MUST deactivate them in `onExitImpl`** — the next state's `onEntry` may not run if an error interrupts the transition.
+2. **`valveSafetyShutdownCheck()` runs every loop** — it must whitelist ALL states that legitimately need the valve open (brew, manual flush, active backflush filling). If you add a new water-flow state, update this check.
+3. **`BaseState::checkTransitions` enforces PID disable for active operations** — if you add a new operational state, ensure the `constexpr` exclusion list in BaseState.h is correct.
+4. **Stale request flags** — states that cannot act on action requests (PID_DISABLED, STANDBY, error states) must drain incoming flags to prevent unexpected transitions on recovery.
+5. **State entry must be idempotent for hardware** — `update()` should reinforce the desired hardware state (e.g., keep pump enabled) because `valveSafetyShutdownCheck` or other safety mechanisms may turn things off between cycles.
+6. **Compare against original** — the reference implementation is at `/Users/marbaced/projects/clevercoffee`. When in doubt about hardware behavior, check `src/main.cpp` (`handleMachineState`), `src/brewHandler.h`, and `src/hotWaterHandler.h`.

--- a/docs/adr/0003-state-machine-hardware-control-contract.md
+++ b/docs/adr/0003-state-machine-hardware-control-contract.md
@@ -1,0 +1,44 @@
+# ADR-0003: State Machine Hardware Control Contract
+
+## Status
+
+Accepted
+
+## Context
+
+During the refactoring from the original flat state machine (`handleMachineState()` in main.cpp) to a class-based state pattern, several hardware control bugs were introduced:
+
+1. **ManualFlushRunningState** set a flag but never activated pump/valve hardware.
+2. **valveSafetyShutdownCheck()** only excluded brew states, causing it to force-close the valve during manual flush and backflush filling.
+3. **PidDisabledState** did not drain stale action request flags, causing unexpected brew starts on PID re-enable.
+4. **No state enforced PID disable during active operations** (brew, steam, backflush), unlike the original which checked `!pidON` in every operational state.
+5. **ManualFlush had no stop mechanism** — the switch release was not handled.
+
+The root cause: the original project controlled hardware directly in procedural functions (`brew()`, `manualFlush()`, `hotWaterHandler()`) called every loop. The refactored state pattern moved responsibility to `onEntry`/`onExit`/`update` methods, but some states were implemented as "flag-only" without the corresponding hardware control.
+
+## Decision
+
+### Hardware control ownership
+
+Each state that requires active hardware (pump, valve) **must**:
+- Enable hardware in `onEntryImpl()`
+- Reinforce hardware state in `update()` (defense against safety checks toggling it off)
+- Disable hardware in `onExitImpl()`
+
+### Safety layers
+
+1. **`valveSafetyShutdownCheck()`** — runs every loop, closes valve unless in an explicit whitelist of water-flow states (brew active, manual flush, backflush filling/flushing).
+2. **`BaseState::checkTransitions()`** — uses `constexpr if` to enforce PID-disable transitions for all operational states. Excluded: PID_NORMAL (handles it explicitly), PID_DISABLED, STANDBY, INIT, and error states.
+3. **`HardwareManager`** — force-disables pump on water tank empty detection, refuses `enablePump()` when tank is empty or emergency mode is active.
+
+### Flag lifecycle
+
+- **On state entry**: drain all action flags that cannot be acted upon in that state.
+- **During update**: drain incoming flags only when the condition preventing action persists (guarded by the same check used for exit transitions).
+- **Never drain wake-up signals**: STANDBY preserves `brewStartRequested` and `steamStartRequested` as intentional wake triggers.
+
+## Consequences
+
+- Adding a new water-flow state requires updating `valveSafetyShutdownCheck()` whitelist AND the `BaseState` constexpr exclusion list.
+- Every state's hardware contract is explicit in its entry/exit/update methods — no implicit "the loop handles it" assumptions.
+- Defense-in-depth: multiple layers ensure hardware safety even if one layer has a bug.

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -1,0 +1,99 @@
+# Manual Integration Test Checklist
+
+Pre-release validation. Every item must pass before merging to main or tagging a release.
+
+## Prerequisites
+
+- Device flashed with the build under test (USB or OTA)
+- Device connected to WiFi and reachable at its hostname (e.g. `test-silvia2.lan`)
+- Serial monitor available (USB) **or** telnet client for WiFi logging
+
+## 1. Build & Unit Tests
+
+- [ ] `pio run -e esp32_usb` — firmware compiles without errors
+- [ ] `pio test -e native_test` — all native tests pass (280/280 or current count)
+- [ ] `pio run --target format -e esp32_usb` — no formatting changes
+
+## 2. OTA Update
+
+- [ ] `pio run -e esp32_ota -t upload` completes at 100% with "Result: OK"
+- [ ] Device reboots and responds to `/api/health` within 15s after OTA
+
+## 3. USB Serial Logging
+
+- [ ] `pio device monitor -e esp32_usb` shows boot log lines (WiFi connect, state transitions)
+- [ ] Log lines appear at INFO level during normal operation (e.g. temperature readings, state changes)
+- [ ] Log level filtering works (DEBUG messages hidden at INFO level)
+
+## 4. WiFi Telnet Logging
+
+- [ ] `nc <hostname> 23` connects and shows "CleverCoffee log stream connected"
+- [ ] Log lines appear when activity occurs (API calls, state changes)
+- [ ] Idle machine at INFO level = quiet telnet is expected (not a bug)
+- [ ] Telnet disconnect/reconnect works cleanly
+
+## 5. Web API Endpoints
+
+Test each with `curl -s http://<hostname>/<endpoint>` and verify non-empty valid JSON response:
+
+- [ ] `GET /api/health` — HTTP 200
+- [ ] `GET /api/status` — JSON with temperature, setpoint, machineState, uptime
+- [ ] `GET /api/parameters?filter=all` — full parameter list (~19KB JSON array)
+- [ ] `GET /api/config` — current config JSON
+- [ ] `GET /api/history` — temperature history with currentTemps/targetTemps/heaterPowers arrays
+- [ ] `GET /api/temperatures` — current temperature reading
+- [ ] `GET /api/nvs-debug` — NVS metadata and parameters
+
+## 6. Web UI
+
+- [ ] `GET /ui/` — serves SPA (HTTP 200, HTML content)
+- [ ] `GET /ui/config/behavior` — serves SPA (HTTP 200)
+- [ ] UI loads fully in browser without console errors
+- [ ] UI displays current temperature and machine state
+
+## 7. Concurrent Load (Telnet + API)
+
+This tests the critical OOM scenario that caused crashes.
+
+- [ ] Connect telnet: `nc <hostname> 23`
+- [ ] With telnet open, load UI page in browser — device must not crash
+- [ ] With telnet open, hit 5+ API endpoints in rapid succession — all return HTTP 200
+- [ ] After load burst, `/api/health` still responds with HTTP 200
+- [ ] Repeat after fresh reboot (boot window is the most fragile period)
+
+## 8. Stability
+
+- [ ] Device does not crash/reboot during 5 minutes of idle operation
+- [ ] No `abort()`, watchdog reset, or stack overflow in serial output
+- [ ] Free heap stays above 50KB during normal operation (`/api/nvs-debug` → `free_heap` field)
+
+## 9. Temperature Sensor Robustness (TSIC)
+
+A single out-of-range TSIC sample must never trip emergency stop or flood the log.
+
+- [ ] During idle/heating, logs do NOT continuously repeat `Temperature not stable`
+      (the change-rate stabilisation must latch within the first few readings)
+- [ ] A transient bad reading is logged once as `Temperature reading out of range, ignoring: …`
+      and does NOT produce an `Emergency: Invalid temperature reading` entry
+- [ ] If emergency does trigger (sustained overtemp/fault), recovery returns to
+      `PID Normal` (state 20), not `PID disabled` — see ADR 0002 / emergency recovery fix
+
+## 9. Frontend (when `ui/` files changed)
+
+Run from `ui/packages/frontend`:
+
+- [ ] `pnpm test:run` — all frontend tests pass
+- [ ] `pnpm lint` — no lint errors
+- [ ] `pnpm tsc` — no TypeScript errors
+
+---
+
+## Quick Smoke Test (minimum for non-release changes)
+
+If the full checklist is too heavy for a minor change, at least verify:
+
+1. Build passes
+2. Native tests pass
+3. `/api/health` responds 200
+4. `/api/parameters?filter=all` returns full JSON
+5. No crash when loading UI with telnet connected

--- a/docs/state-machine-architecture.md
+++ b/docs/state-machine-architecture.md
@@ -1,0 +1,244 @@
+# State Machine Architecture & Hardware Control
+
+Complete reference for the state machine, all transitions, and hardware (pump, valve, heater) behavior.
+
+## How the State Machine Runs
+
+Each state is a class inheriting from `BaseState<StateId, DerivedState>`. Every main-loop iteration:
+
+```
+StateMachine::update()
+  ├── currentState->update(context)          ← periodic logic
+  ├── currentState->checkTransitions(context) ← check if transition needed
+  │     ├── BaseState safety checks (emergency / sensor / tank / PID)
+  │     └── State-specific transition checks
+  └── if transition needed:
+        ├── oldState->onExit(context)
+        ├── create new state
+        └── newState->onEntry(context)
+
+→ valveSafetyShutdownCheck()                 ← closes valve if not in water-flow state
+→ display update
+```
+
+---
+
+## Full State Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> INIT
+
+    INIT --> PID_NORMAL : PID enabled in config
+    INIT --> PID_DISABLED : PID disabled in config
+
+    PID_NORMAL --> PID_DISABLED : PID turned off (web UI)
+    PID_DISABLED --> PID_NORMAL : PID turned on (web UI)
+
+    PID_NORMAL --> STANDBY : standby timeout / web UI
+    PID_DISABLED --> STANDBY : standby timeout
+    STANDBY --> PID_NORMAL : user activity / brew or steam request
+    STANDBY --> PID_DISABLED : wake but PID still off
+
+    PID_NORMAL --> BREW_PREINFUSION : brew start (auto mode)
+    PID_NORMAL --> BREW_RUNNING : brew start (manual mode)
+    PID_NORMAL --> STEAM_RUNNING : steam start
+    PID_NORMAL --> BACKFLUSH_IDLE : enter backflush (web UI)
+
+    BREW_PREINFUSION --> BREW_PREINFUSION_PAUSE : preinfusion time elapsed
+    BREW_PREINFUSION --> PID_NORMAL : brew stop
+
+    BREW_PREINFUSION_PAUSE --> BREW_RUNNING : pause time elapsed
+    BREW_PREINFUSION_PAUSE --> PID_NORMAL : brew stop
+
+    BREW_RUNNING --> BREW_FINISHED : target time/weight reached
+    BREW_RUNNING --> PID_NORMAL : brew stop
+
+    BREW_FINISHED --> PID_NORMAL : 3s timeout
+
+    STEAM_RUNNING --> PID_NORMAL : steam stop
+
+    BACKFLUSH_IDLE --> MANUAL_FLUSH_RUNNING : long press brew switch
+    BACKFLUSH_IDLE --> BACKFLUSH_FILLING : brew switch press (start cycle)
+    BACKFLUSH_IDLE --> PID_NORMAL : exit backflush (web UI)
+
+    MANUAL_FLUSH_RUNNING --> BACKFLUSH_IDLE : brew switch release
+
+    BACKFLUSH_FILLING --> BACKFLUSH_FLUSHING : fill time elapsed
+    BACKFLUSH_FLUSHING --> BACKFLUSH_FILLING : flush time elapsed (more cycles)
+    BACKFLUSH_FLUSHING --> BACKFLUSH_FINISHED : all cycles complete
+
+    BACKFLUSH_FINISHED --> BACKFLUSH_IDLE : reset
+
+    note right of PID_NORMAL
+        BaseState checks EVERY cycle:
+        → Emergency stop   ⇒ EMERGENCY_STOP
+        → Sensor error     ⇒ SENSOR_ERROR
+        → Water tank empty ⇒ WATER_TANK_EMPTY
+        → PID disabled*    ⇒ PID_DISABLED
+        * excludes INIT, PID_NORMAL, PID_DISABLED,
+          STANDBY, and all error states
+    end note
+```
+
+---
+
+## Brew Cycle Detail
+
+```mermaid
+stateDiagram-v2
+    direction LR
+
+    [*] --> BREW_PREINFUSION : brew start (auto)
+
+    BREW_PREINFUSION --> BREW_PREINFUSION_PAUSE : preinfusion time elapsed\n[pump OFF, valve stays OPEN]
+    BREW_PREINFUSION --> PID_NORMAL : brew stop\n[pump OFF, valve→safety check closes it]
+
+    BREW_PREINFUSION_PAUSE --> BREW_RUNNING : pause time elapsed\n[pump ON, valve already OPEN]
+    BREW_PREINFUSION_PAUSE --> PID_NORMAL : brew stop\n[pump OFF, valve→safety check closes it]
+
+    BREW_RUNNING --> BREW_FINISHED : target reached\n[pump OFF, valve CLOSED]
+    BREW_RUNNING --> PID_NORMAL : brew stop\n[pump OFF, valve CLOSED]
+
+    BREW_FINISHED --> PID_NORMAL : 3s timeout
+
+    note right of BREW_PREINFUSION_PAUSE
+        ⚠️ Valve stays OPEN throughout
+        preinfusion → pause → running.
+        Closing valve during pause
+        releases puck pressure!
+    end note
+```
+
+---
+
+## Backflush Cycle Detail
+
+```mermaid
+stateDiagram-v2
+    direction LR
+
+    [*] --> BACKFLUSH_IDLE
+
+    BACKFLUSH_IDLE --> MANUAL_FLUSH_RUNNING : long press\n[pump ON, valve OPEN]
+    MANUAL_FLUSH_RUNNING --> BACKFLUSH_IDLE : release\n[pump OFF, valve CLOSED]
+
+    BACKFLUSH_IDLE --> BACKFLUSH_FILLING : switch press\n[pump ON, valve OPEN]
+    BACKFLUSH_FILLING --> BACKFLUSH_FLUSHING : fill time\n[pump OFF, valve CLOSED]
+    BACKFLUSH_FLUSHING --> BACKFLUSH_FILLING : more cycles\n[pump ON, valve OPEN]
+    BACKFLUSH_FLUSHING --> BACKFLUSH_FINISHED : done
+    BACKFLUSH_FINISHED --> BACKFLUSH_IDLE : reset
+
+    BACKFLUSH_IDLE --> PID_NORMAL : exit backflush
+```
+
+---
+
+## Hardware State per State
+
+| State | Pump | Valve | Heater (PID) | Notes |
+|---|---|---|---|---|
+| INIT | OFF | CLOSED | OFF | Boot-up |
+| PID_NORMAL | OFF † | CLOSED | ACTIVE | † ON only when hot-water switch held |
+| PID_DISABLED | OFF | CLOSED | OFF | All operations blocked, flags drained |
+| STANDBY | OFF | CLOSED | OFF | Power-saving |
+| BREW_PREINFUSION | **ON** | **OPEN** | ACTIVE | Water through puck |
+| BREW_PREINFUSION_PAUSE | OFF | **OPEN** | ACTIVE | Bloom — pressure held |
+| BREW_RUNNING | **ON** | **OPEN** | ACTIVE | Main extraction |
+| BREW_FINISHED | OFF | CLOSED | ACTIVE | 3s result display |
+| STEAM_RUNNING | OFF † | CLOSED | ACTIVE (steam setpoint) | † ON only when injection switch held |
+| MANUAL_FLUSH_RUNNING | **ON** | **OPEN** | ACTIVE | Continuous flush |
+| BACKFLUSH_IDLE | OFF | CLOSED | ACTIVE | Awaiting cycle |
+| BACKFLUSH_FILLING | **ON** | **OPEN** | ACTIVE | Fill portafilter |
+| BACKFLUSH_FLUSHING | OFF | CLOSED | ACTIVE | Drain to drip tray |
+| BACKFLUSH_FINISHED | OFF | CLOSED | ACTIVE | All cycles done |
+| WATER_TANK_EMPTY | OFF | CLOSED | ACTIVE | Pump blocked by HardwareManager |
+| EMERGENCY_STOP | OFF | CLOSED | OFF | Full shutdown |
+| SENSOR_ERROR | OFF | CLOSED | OFF | Safe mode |
+| EEPROM_ERROR | OFF | CLOSED | OFF | Safe mode |
+
+---
+
+## Brew Stop — Valve Closure
+
+> **The valve must stay energized throughout the entire preinfusion → pause → running sequence.** Closing it early releases puck pressure and ruins the shot.
+
+| Stopped from | Who closes the valve | When |
+|---|---|---|
+| BREW_PREINFUSION | `valveSafetyShutdownCheck()` | Same loop iteration, after state machine update |
+| BREW_PREINFUSION_PAUSE | `valveSafetyShutdownCheck()` | Same loop iteration, after state machine update |
+| BREW_RUNNING | `BrewRunningState::onExitImpl` | Immediately on transition |
+
+**Sequence when stopping from preinfusion or pause:**
+1. State transitions to `PID_NORMAL`
+2. `onExitImpl` disables pump — valve stays open
+3. `valveSafetyShutdownCheck()` runs (same loop, after state machine)
+4. Safety check: not in water-flow state → closes valve
+
+---
+
+## Safety Layers
+
+```mermaid
+flowchart TD
+    A[Every loop iteration] --> B[StateMachine::update]
+    B --> C{BaseState::checkTransitions}
+    C -->|Emergency stop| ES[EMERGENCY_STOP\npump OFF, valve CLOSED, heater OFF]
+    C -->|Sensor error| SE[SENSOR_ERROR\npump OFF, valve CLOSED, heater OFF]
+    C -->|Tank empty| TE[WATER_TANK_EMPTY\npump blocked]
+    C -->|PID disabled *| PD[PID_DISABLED\nall flags cleared]
+    C -->|else| SD[State-specific transitions]
+    SD --> V[valveSafetyShutdownCheck]
+    V -->|not water-flow state| VC[Close valve]
+    V -->|water-flow state| VN[Leave valve open]
+
+    style ES fill:#f55,color:#fff
+    style SE fill:#f55,color:#fff
+    style TE fill:#fa0,color:#fff
+    style PD fill:#fa0,color:#fff
+```
+
+> \* PID disable check excludes: `INIT`, `PID_NORMAL`, `PID_DISABLED`, `STANDBY`, and all error states.
+
+**Water-flow states** (valve allowed open): `BREW_PREINFUSION`, `BREW_PREINFUSION_PAUSE`, `BREW_RUNNING`, `MANUAL_FLUSH_RUNNING`, `BACKFLUSH_FILLING`, `BACKFLUSH_FLUSHING`.
+
+### HardwareManager guards (Layer 4)
+- `enablePump()` refuses if tank empty or emergency mode active
+- `updateSafetyState()` force-disables pump when tank empties mid-brew
+- `emergencyShutdown()` kills pump, valve, and heater immediately
+
+---
+
+## Flag Lifecycle
+
+| Flag | Set by | Consumed by | Standby behavior |
+|---|---|---|---|
+| `brewStartRequested` | BrewHandler (switch press) | PidNormalState, BrewFinishedState, StandbyState | **Preserved** (wake trigger) |
+| `brewStopRequested` | BrewHandler (switch release) | Brew states | Cleared |
+| `steamStartRequested` | SteamHandler (switch press) | PidNormalState, StandbyState | **Preserved** (wake trigger) |
+| `steamStopRequested` | SteamHandler (switch release) | SteamRunningState | Cleared |
+| `manualFlushStartRequested` | BrewHandler (long press in backflush) | PidNormalState, BackflushIdleState | Cleared |
+| `manualFlushStopRequested` | BrewHandler (release during flush) | ManualFlushRunningState | Cleared |
+| `backflushEnterRequested` | Web UI / MQTT | PidNormalState | Cleared |
+| `backflushCycleStartRequested` | BrewHandler (press in backflush idle) | BackflushIdleState, BackflushFinishedState | Cleared |
+| `backflushStopRequested` | BrewHandler (press during cycle) | BackflushFillingState, BackflushFlushingState | Cleared |
+| `normalOperationRequested` | Web UI | StandbyState | Cleared |
+| `standbyRequested` | Web UI | PidNormalState | Cleared |
+
+### Drain rules
+
+| State | What gets cleared | Why |
+|---|---|---|
+| `PidDisabledState` (entry + update) | **All** flags | Prevent stale flags from triggering operations on re-enable |
+| `StandbyState` (entry) | Stop flags only | Preserve brew/steam start as wake triggers |
+| All other states | The one flag they act on | Normal consumption |
+
+### Helper methods
+
+```cpp
+// Drain all flags — use in PID_DISABLED and error states
+void MachineStateContext::clearAllActionRequests() noexcept;
+
+// Drain stop flags only — use in STANDBY (preserves wake triggers)
+void MachineStateContext::clearStaleStopRequests() noexcept;
+```

--- a/include/clevercoffee/constants/Timing.h
+++ b/include/clevercoffee/constants/Timing.h
@@ -26,8 +26,6 @@ constexpr unsigned long DEBUG_LOG_THROTTLE_MS = 5000; ///< Throttle debug logs t
 // Recovery and error handling timeouts
 constexpr unsigned long ERROR_RECOVERY_DELAY_MS    = 5000;   ///< Delay before attempting error recovery
 constexpr unsigned long EEPROM_RECOVERY_TIMEOUT_MS = 300000; ///< EEPROM recovery timeout (5 minutes)
-constexpr unsigned long MAX_SENSOR_ERROR_DURATION_MS =
-    60000; ///< Maximum sensor error duration before disabling PID (1 minute)
 constexpr unsigned long STANDBY_TIMER_RESET_INTERVAL_MS =
     30000; ///< Interval for resetting standby timer in PID state (30 seconds)
 

--- a/include/clevercoffee/handlers/BrewHandler.h
+++ b/include/clevercoffee/handlers/BrewHandler.h
@@ -107,8 +107,17 @@ class BrewHandler : public SwitchBasedHandler {
     }
 
     void valveSafetyShutdownCheck() {
-        // Safety check to ensure valve is closed when not brewing
-        if (!isBrewActive() && valveRelay_) {
+        // Safety check to ensure valve is closed when not in an active water-flow state.
+        // Mirrors the original: valve stays open during brew, manual flush, and backflush.
+        if (!valveRelay_) return;
+        auto* context = systemContext_.machineStateContext();
+        if (!context) return;
+        const auto state           = context->getCurrentStateId();
+        const bool waterFlowActive = (isBrewState(state) && state != MachineStateId::BREW_FINISHED) ||
+                                     isManualFlushState(state) ||
+                                     (isBackflushState(state) && state != MachineStateId::BACKFLUSH_IDLE &&
+                                      state != MachineStateId::BACKFLUSH_FINISHED);
+        if (!waterFlowActive) {
             setRelayState(valveRelay_, false);
         }
     }
@@ -184,7 +193,8 @@ class BrewHandler : public SwitchBasedHandler {
             if (!context) return;
             const auto currentState = context->getCurrentStateId();
 
-            if (context->isBackflushModeActive() || isBackflushState(currentState)) {
+            if (context->isBackflushModeActive() || isBackflushState(currentState) ||
+                isManualFlushState(currentState)) {
                 if (reading == HIGH) {
                     if (currentState == MachineStateId::BACKFLUSH_IDLE && switch_ != nullptr &&
                         switch_->longPressDetected()) {
@@ -195,10 +205,15 @@ class BrewHandler : public SwitchBasedHandler {
                     } else if (isBackflushState(currentState)) {
                         context->setBackflushStopRequested(true);
                     }
-                } else if (reading == LOW && switchType == Hardware::SwitchType::TOGGLE &&
-                           isBackflushState(currentState) && currentState != MachineStateId::BACKFLUSH_IDLE &&
-                           currentState != MachineStateId::BACKFLUSH_FINISHED) {
-                    context->setBackflushStopRequested(true);
+                } else if (reading == LOW) {
+                    // Switch released — stop manual flush or backflush cycle
+                    if (isManualFlushState(currentState)) {
+                        context->setManualFlushStopRequested(true);
+                    } else if (switchType == Hardware::SwitchType::TOGGLE && isBackflushState(currentState) &&
+                               currentState != MachineStateId::BACKFLUSH_IDLE &&
+                               currentState != MachineStateId::BACKFLUSH_FINISHED) {
+                        context->setBackflushStopRequested(true);
+                    }
                 }
                 lastSwitchReading_ = reading;
                 return;

--- a/include/clevercoffee/hardware/HardwareManager.h
+++ b/include/clevercoffee/hardware/HardwareManager.h
@@ -174,12 +174,32 @@ class HardwareManager : public IHardwareContext {
     void emergencyShutdown() noexcept override;
 
     /**
+     * @brief Clear emergency mode after conditions have resolved.
+     *
+     * Only call this after a genuine emergency has been confirmed cleared
+     * (e.g. temperature has dropped back to safe range). Allows hardware to
+     * resume normal operation.
+     */
+    void clearEmergencyMode() noexcept;
+
+    /**
+     * @brief Safely shut down all hardware without activating emergency mode.
+     *
+     * Use for intentional power-off, standby transitions, and safe shutdowns.
+     * Does NOT set emergencyMode_ — hardware can be re-enabled normally.
+     */
+    void safeHardwareShutdown() noexcept;
+
+    /**
      * @brief Update safety state from sensors
      * Called periodically to check water tank status
      */
     void updateSafetyState() noexcept;
 
   private:
+    /// @brief Internal helper: turns off all relays and resets state tracking.
+    void disableAllHardware() noexcept;
+
     // Configuration reference (not owned)
     const Config& config_;
 

--- a/include/clevercoffee/hardware/tempsensors/TempSensor.h
+++ b/include/clevercoffee/hardware/tempsensors/TempSensor.h
@@ -121,8 +121,10 @@ class TempSensor : public CleverCoffee::ISensor {
             return Error(ErrorCode::SENSOR_TIMEOUT, "Temperature read timeout");
         }
 
-        // Try to update temperature
-        double temp_value{};
+        // Seed with the last good reading: sensors (e.g. TSIC) use the incoming
+        // value as the previous sample to decide whether the signal has stabilised.
+        // A fresh 0.0 here would prevent stabilisation from ever latching.
+        double temp_value = last_temperature_;
         if (sample_temperature(temp_value)) {
             read_in_progress_ = false;
             last_temperature_ = temp_value;

--- a/include/clevercoffee/state/BaseState.h
+++ b/include/clevercoffee/state/BaseState.h
@@ -152,6 +152,19 @@ std::optional<MachineStateId> BaseState<StateId, DerivedState>::checkTransitions
         return MachineStateId::WATER_TANK_EMPTY;
     }
 
+    // PID disable check — force transition for active operation states.
+    // Excluded: PID_DISABLED (already there), STANDBY (PID intentionally off),
+    //           error/emergency states, and INIT.
+    if constexpr (StateId != MachineStateId::PID_DISABLED && StateId != MachineStateId::PID_NORMAL &&
+                  StateId != MachineStateId::STANDBY && StateId != MachineStateId::INIT &&
+                  StateId != MachineStateId::EMERGENCY_STOP && StateId != MachineStateId::SENSOR_ERROR &&
+                  StateId != MachineStateId::WATER_TANK_EMPTY && StateId != MachineStateId::EEPROM_ERROR) {
+        if (!context.isPidRuntimeEnabled()) {
+            context.logStateTransition(getStateId(), MachineStateId::PID_DISABLED, "PID disabled during operation");
+            return MachineStateId::PID_DISABLED;
+        }
+    }
+
     // Delegate to derived class for state-specific transitions
     return checkSpecificTransitions(context);
 }

--- a/include/clevercoffee/state/IHardwareContext.h
+++ b/include/clevercoffee/state/IHardwareContext.h
@@ -306,6 +306,22 @@ class IHardwareContext {
      */
     virtual void emergencyShutdown() noexcept = 0;
 
+    /**
+     * @brief Safe hardware shutdown — turns off all hardware without entering emergency mode.
+     *
+     * Use for intentional power-off and standby transitions. Hardware can be re-enabled
+     * normally afterwards. Does NOT set emergency mode.
+     */
+    virtual void safeHardwareShutdown() noexcept = 0;
+
+    /**
+     * @brief Clear emergency mode after conditions have been confirmed resolved.
+     *
+     * Call this once the root cause of an emergency (e.g. over-temperature) has cleared
+     * so that hardware can resume normal operation.
+     */
+    virtual void clearEmergencyMode() noexcept = 0;
+
     /** @} */
 };
 

--- a/include/clevercoffee/state/MachineStateContext.h
+++ b/include/clevercoffee/state/MachineStateContext.h
@@ -626,6 +626,38 @@ class MachineStateContext : public CleverCoffee::IHardwareContext,
      */
     void setHotWaterActivity(bool active) noexcept;
 
+    /**
+     * @brief Clear ALL pending action request flags.
+     *
+     * Use on entry to states that cannot act on any requests (PID_DISABLED, error states).
+     * Prevents stale flags from causing unexpected transitions when the machine recovers.
+     */
+    void clearAllActionRequests() noexcept {
+        requestBrewStart_           = false;
+        requestBrewStop_            = false;
+        requestSteamStart_          = false;
+        requestSteamStop_           = false;
+        requestManualFlushStart_    = false;
+        requestManualFlushStop_     = false;
+        requestEnterBackflush_      = false;
+        requestBackflushCycleStart_ = false;
+        requestBackflushStop_       = false;
+        requestNormalOperation_     = false;
+        requestStandby_             = false;
+    }
+
+    /**
+     * @brief Clear only "stop" action flags (preserve start/wake signals).
+     *
+     * Use on entry to STANDBY — start requests (brew, steam) are kept as wake triggers.
+     */
+    void clearStaleStopRequests() noexcept {
+        requestBrewStop_        = false;
+        requestSteamStop_       = false;
+        requestManualFlushStop_ = false;
+        requestBackflushStop_   = false;
+    }
+
     // === Display Functions ===
 
     /**
@@ -730,6 +762,8 @@ class MachineStateContext : public CleverCoffee::IHardwareContext,
     void openSolenoid() noexcept override;
     void closeSolenoid() noexcept override;
     void emergencyShutdown() noexcept override;
+    void safeHardwareShutdown() noexcept override;
+    void clearEmergencyMode() noexcept override;
 
     // === IConfigContext Interface Implementation ===
 

--- a/include/clevercoffee/state/states/ErrorStates.h
+++ b/include/clevercoffee/state/states/ErrorStates.h
@@ -18,9 +18,7 @@ class SensorErrorState : public BaseState<MachineStateId::SENSOR_ERROR, SensorEr
     std::optional<MachineStateId> checkSpecificTransitions(MachineStateContext& context) override;
 
   private:
-    static constexpr unsigned int MAX_RECOVERY_ATTEMPTS = 3;
-    unsigned long                 errorStartTime_       = 0; // Fresh on each entry (new instance)
-    unsigned int                  recoveryAttempts_     = 0; // Fresh on each entry (new instance)
+    unsigned long errorStartTime_ = 0; // Fresh on each entry (new instance)
 };
 
 class WaterTankEmptyState : public BaseState<MachineStateId::WATER_TANK_EMPTY, WaterTankEmptyState> {

--- a/include/clevercoffee/utils/SystemUtils.h
+++ b/include/clevercoffee/utils/SystemUtils.h
@@ -22,6 +22,7 @@ inline void setRuntimePidState(CleverCoffee::SystemContext& systemContext, const
     static std::mutex           pid_mutex;
     std::lock_guard<std::mutex> lock(pid_mutex);
 
+    LOGF(INFO, "PID runtime state change: %s", enabled ? "ENABLED" : "DISABLED");
     systemContext.setProcessPidEnabled(enabled);
 }
 

--- a/src/control/ProcessController.cpp
+++ b/src/control/ProcessController.cpp
@@ -331,6 +331,7 @@ bool ProcessController::testEmergencyConditions() {
         // Emergency was active but conditions are now cleared
         emergencyStopManager_->clearEmergency();
         systemContext_.setEmergencyStop(false);
+        hardwareManager_.clearEmergencyMode();
         LOG(INFO, "Emergency conditions cleared - system can resume");
     }
     return false;
@@ -492,8 +493,9 @@ void ProcessController::performSafeShutdown() {
     pidOutput_ = 0;
     systemContext_.setProcessPidOutput(0);
 
-    // Delegate hardware shutdown to HardwareManager
-    hardwareManager_.emergencyShutdown();
+    // Shut down hardware safely — does NOT set emergencyMode_ so hardware can
+    // be re-enabled after recovery (e.g. after standby or user power-off).
+    hardwareManager_.safeHardwareShutdown();
 
     LOG(INFO, "ProcessController safe shutdown completed");
 }

--- a/src/hardware/HardwareManager.cpp
+++ b/src/hardware/HardwareManager.cpp
@@ -529,8 +529,22 @@ void HardwareManager::closeSolenoid() noexcept {
 void HardwareManager::emergencyShutdown() noexcept {
     LOG(ERROR, "EMERGENCY SHUTDOWN ACTIVATED");
     emergencyMode_ = true;
+    disableAllHardware();
+    LOG(ERROR, "All hardware disabled - system in emergency mode");
+}
 
-    // Immediately disable all hardware
+void HardwareManager::clearEmergencyMode() noexcept {
+    LOG(INFO, "Emergency mode cleared - hardware can resume normal operation");
+    emergencyMode_ = false;
+}
+
+void HardwareManager::safeHardwareShutdown() noexcept {
+    LOG(INFO, "Safe hardware shutdown - disabling all hardware");
+    disableAllHardware();
+    // emergencyMode_ intentionally NOT set — hardware can be re-enabled normally
+}
+
+void HardwareManager::disableAllHardware() noexcept {
     if (heaterRelay_ && heaterEnabled_) {
         heaterRelay_->off();
         heaterEnabled_ = false;
@@ -544,8 +558,6 @@ void HardwareManager::emergencyShutdown() noexcept {
         valveState_ = CleverCoffee::Hardware::ValveState::CLOSED;
     }
     solenoidOpen_ = false;
-
-    LOG(ERROR, "All hardware disabled - system in emergency mode");
 }
 
 void HardwareManager::updateSafetyState() noexcept {

--- a/src/hardware/tempsensors/TempSensorTSIC.cpp
+++ b/src/hardware/tempsensors/TempSensorTSIC.cpp
@@ -32,15 +32,12 @@ bool TempSensorTSIC::sample_temperature(double& temperature) const {
     if (!validTemps) {
         temp = tsicSensor_->getTemp(INITIAL_CHANGERATE);
 
-        // if current and previous reading is in range and their difference is low then reduce changerate
-        if (temp > 0.0 && temp < 180.0) {
-            if (temperature > 0.0 && temperature < 180.0 && abs(temperature - temp) < RUNTIME_CHANGERATE) {
-                validTemps = true;
-            } else {
-                LOGF(WARNING, "Temperature not stable");
-            }
-        } else if (temp != 221 && temp != 222) {
-            LOGF(WARNING, "Temperature reading not within 0 - 180°C range: %0.01f°C", temp);
+        // Once the current and previous readings are both in range and close together,
+        // latch onto the tighter runtime change-rate so glitch smoothing becomes active.
+        // `temperature` carries the previous good reading (seeded by the caller).
+        if (temp > 0.0 && temp < 180.0 && temperature > 0.0 && temperature < 180.0 &&
+            abs(temperature - temp) < RUNTIME_CHANGERATE) {
+            validTemps = true;
         }
     } else {
         temp = tsicSensor_->getTemp(RUNTIME_CHANGERATE);
@@ -53,6 +50,14 @@ bool TempSensorTSIC::sample_temperature(double& temperature) const {
 
     if (temp == 221) {
         LOG(WARNING, "Temperature sensor not connected");
+        return false;
+    }
+
+    // Reject physically impossible readings (sensor glitches) instead of passing them
+    // through as valid. A single spurious value (e.g. -2.9°C) must not trip emergency
+    // stop; treating it as a failed read keeps the last good cached value instead.
+    if (temp <= 0.0 || temp >= 180.0) {
+        LOGF(WARNING, "Temperature reading out of range, ignoring: %.1f°C", temp);
         return false;
     }
 

--- a/src/state/MachineStateContext.cpp
+++ b/src/state/MachineStateContext.cpp
@@ -594,3 +594,11 @@ void MachineStateContext::closeSolenoid() noexcept {
 void MachineStateContext::emergencyShutdown() noexcept {
     hardwareManager_.emergencyShutdown();
 }
+
+void MachineStateContext::safeHardwareShutdown() noexcept {
+    hardwareManager_.safeHardwareShutdown();
+}
+
+void MachineStateContext::clearEmergencyMode() noexcept {
+    hardwareManager_.clearEmergencyMode();
+}

--- a/src/state/states/BrewStates.cpp
+++ b/src/state/states/BrewStates.cpp
@@ -79,9 +79,10 @@ void BrewPreinfusionState::onEntryImpl(MachineStateContext& context) {
 }
 
 void BrewPreinfusionState::onExitImpl(MachineStateContext& context) {
-    // Safety: Ensure pump and valve are disabled when exiting preinfusion
-    cleanupPumpAndValve(context);
-    LOG(DEBUG, "Brew preinfusion exit - hardware cleaned up");
+    // Pump off only — valve stays open to hold puck pressure through pause/running.
+    // Valve closure happens in BREW_RUNNING::onExitImpl or via valveSafetyShutdownCheck on abort.
+    context.disablePump();
+    LOG(DEBUG, "Brew preinfusion exit - pump off, valve held for pressure");
 }
 
 void BrewPreinfusionState::update(MachineStateContext& context) {
@@ -150,8 +151,9 @@ std::optional<MachineStateId> BrewPreinfusionState::checkSpecificTransitions(Mac
 
 void BrewPreinfusionPauseState::onEntryImpl(MachineStateContext& context) {
     LOG(INFO, "Brew preinfusion pause - blooming phase");
-    // Ensure pump and valve are closed during pause
-    cleanupPumpAndValve(context);
+    // Stop pump only — valve stays energized to retain pressure in the puck
+    context.disablePump();
+    context.openWaterValve();
     // Store preinfusion time before pause
     if (context.systemContext().processController()) {
         const double preinfusionTimeMs = context.getPreInfusionTime() * 1000.0;
@@ -160,15 +162,16 @@ void BrewPreinfusionPauseState::onEntryImpl(MachineStateContext& context) {
 }
 
 void BrewPreinfusionPauseState::onExitImpl(MachineStateContext& context) {
-    // Safety: Ensure pump and valve are disabled when exiting preinfusion pause
-    cleanupPumpAndValve(context);
-    LOG(DEBUG, "Brew preinfusion pause exit - hardware cleaned up");
+    // Pump off only — valve stays open to hold puck pressure through running.
+    // Valve closure happens in BREW_RUNNING::onExitImpl or via valveSafetyShutdownCheck on abort.
+    context.disablePump();
+    LOG(DEBUG, "Brew preinfusion pause exit - pump off, valve held for pressure");
 }
 
 void BrewPreinfusionPauseState::update(MachineStateContext& context) {
-    // Ensure pump and valve remain closed during pause
+    // Pump off during bloom; keep valve energized to hold pressure
     context.disablePump();
-    context.closeWaterValve();
+    context.openWaterValve();
 
     // Update brew time (preinfusion time + pause elapsed time)
     if (context.systemContext().processController()) {

--- a/src/state/states/EmergencyStopState.cpp
+++ b/src/state/states/EmergencyStopState.cpp
@@ -23,6 +23,11 @@ void EmergencyStopState::onEntryImpl(MachineStateContext& context) {
 
 void EmergencyStopState::onExitImpl(MachineStateContext& context) {
     LOG(INFO, "Emergency stop cleared - System ready for restart");
+    // Emergency entry forced runtime PID off (performEmergencyShutdown). Restore it
+    // from config so recovery resumes heating instead of leaving the machine stuck in
+    // PID_DISABLED ("disabled manually"). Config stays the source of truth: if the user
+    // had PID disabled, it remains disabled. Mirrors StandbyState::onExitImpl.
+    context.setPidRuntimeState(context.isPidConfigEnabled());
 }
 
 void EmergencyStopState::update(MachineStateContext& context) {
@@ -42,7 +47,7 @@ std::optional<MachineStateId> EmergencyStopState::checkSpecificTransitions(Machi
 }
 
 void EmergencyStopState::performEmergencyShutdown(MachineStateContext& context) {
-    context.performSafeShutdown();
+    context.emergencyShutdown();
     context.setPidRuntimeState(false);
 }
 

--- a/src/state/states/ErrorStates.cpp
+++ b/src/state/states/ErrorStates.cpp
@@ -13,10 +13,7 @@
 void SensorErrorState::onEntryImpl(MachineStateContext& context) {
     LOG(ERROR, "Sensor error detected - entering safe mode");
     context.enterSafeMode();
-    // Fresh instance - initialize error tracking
-    errorStartTime_   = millis();
-    recoveryAttempts_ = 1;
-    LOGF(INFO, "Sensor error recovery attempt %u/%u", recoveryAttempts_, MAX_RECOVERY_ATTEMPTS);
+    errorStartTime_ = millis();
 }
 
 void SensorErrorState::onExitImpl(MachineStateContext& context) {
@@ -41,27 +38,20 @@ std::optional<MachineStateId> SensorErrorState::checkSpecificTransitions(Machine
     unsigned long errorDuration = millis() - errorStartTime_;
 
     if (!context.hasSensorError() && !context.hasTemperatureError()) {
-        // Error resolved - check recovery delay
+        // Error resolved - wait for recovery delay before resuming
         using CleverCoffee::Timing::ERROR_RECOVERY_DELAY_MS;
         if (errorDuration > ERROR_RECOVERY_DELAY_MS) {
             return transitionToPidState(context, "Sensor error recovered");
         }
     } else {
-        // Error still present - reset timer
+        // Error still present - keep resetting the clock so recovery delay
+        // is measured from when the error actually clears, not from entry.
         errorStartTime_ = millis();
     }
 
-    // Check if error has persisted too long or too many recovery attempts
-    using CleverCoffee::Timing::MAX_SENSOR_ERROR_DURATION_MS;
-    if (errorDuration > MAX_SENSOR_ERROR_DURATION_MS || recoveryAttempts_ >= MAX_RECOVERY_ATTEMPTS) {
-        const char* reason = (recoveryAttempts_ >= MAX_RECOVERY_ATTEMPTS)
-                                 ? "Too many sensor recovery attempts - disabling PID for safety"
-                                 : "Persistent sensor error - disabling PID for safety";
-        context.logStateTransition(getStateId(), MachineStateId::PID_DISABLED, reason);
-        context.setPidRuntimeState(false);
-        return MachineStateId::PID_DISABLED;
-    }
-
+    // Stay in SENSOR_ERROR until error resolves — never transition to PID_DISABLED.
+    // A persistent sensor error requires the user to investigate; silently
+    // disabling the PID hides the problem and prevents normal recovery.
     return std::nullopt;
 }
 

--- a/src/state/states/PidStates.cpp
+++ b/src/state/states/PidStates.cpp
@@ -112,11 +112,20 @@ void PidNormalState::resetStandbyTimerIfNeeded(MachineStateContext& context) con
 void PidDisabledState::onEntryImpl(MachineStateContext& context) {
     LOG(INFO, "PID disabled - operations without temperature control");
     context.setPidRuntimeState(false);
-    // Safety: Disable pump when PID is disabled to prevent runaway water dispensing
+    // Safety: Disable pump and close valve when PID is disabled
     context.disablePump();
+    context.closeWaterValve();
+    // Drain any stale action request flags to prevent unexpected transitions on re-enable
+    context.clearAllActionRequests();
 }
 
 void PidDisabledState::update(MachineStateContext& context) {
+    // Only drain stale action flags if PID remains disabled.
+    // If PID was just re-enabled, skip draining so PID_NORMAL can process pending requests.
+    if (!context.isPidRuntimeEnabled()) {
+        context.clearAllActionRequests();
+    }
+
     LOGF(DEBUG,
          "PID Disabled: Temp=%.1f°C, PidEnabled=%s",
          context.getCurrentTemperature(),
@@ -127,6 +136,12 @@ std::optional<MachineStateId> PidDisabledState::checkSpecificTransitions(Machine
     if (context.isPidRuntimeEnabled()) {
         context.logStateTransition(getStateId(), MachineStateId::PID_NORMAL, "PID enabled");
         return MachineStateId::PID_NORMAL;
+    }
+    // Check standby timeout (mirrors original kPidDisabled behavior)
+    context.initializeStandbyTimerIfNeeded();
+    if (context.shouldEnterStandby()) {
+        context.logStateTransition(getStateId(), MachineStateId::STANDBY, "Entering standby mode");
+        return MachineStateId::STANDBY;
     }
     return std::nullopt;
 }

--- a/src/state/states/SystemStates.cpp
+++ b/src/state/states/SystemStates.cpp
@@ -15,8 +15,13 @@ void StandbyState::onEntryImpl(MachineStateContext& context) {
     LOG(INFO, "Entering standby mode - reducing power consumption");
     context.enterStandbyMode();
     context.setSteamMode(false);
+    // Safety: Ensure pump and valve are off when entering standby
+    context.disablePump();
+    context.closeWaterValve();
     // Disable runtime PID (does not modify config - config remains source of truth)
     context.setPidRuntimeState(false);
+    // Drain stale stop flags (preserve start flags as wake triggers)
+    context.clearStaleStopRequests();
 }
 
 void StandbyState::onExitImpl(MachineStateContext& context) {
@@ -51,16 +56,24 @@ std::optional<MachineStateId> StandbyState::checkSpecificTransitions(MachineStat
 }
 
 void ManualFlushRunningState::onEntryImpl(MachineStateContext& context) {
-    LOG(INFO, "Manual flush mode activated - hardware controlled by handlers");
+    LOG(INFO, "Manual flush mode activated");
     context.setManualFlushState(true);
+    context.enablePump();
+    context.openWaterValve();
 }
 
 void ManualFlushRunningState::onExitImpl(MachineStateContext& context) {
     LOG(INFO, "Exiting manual flush mode");
+    context.disablePump();
+    context.closeWaterValve();
     context.setManualFlushState(false);
 }
 
 void ManualFlushRunningState::update(MachineStateContext& context) {
+    // Keep pump and valve active during manual flush
+    context.enablePump();
+    context.openWaterValve();
+
     LOGF(DEBUG,
          "Manual Flush Running: Temp=%.1f°C, Pressure=%.1fbar",
          context.getCurrentTemperature(),
@@ -70,10 +83,12 @@ void ManualFlushRunningState::update(MachineStateContext& context) {
 std::optional<MachineStateId> ManualFlushRunningState::checkSpecificTransitions(MachineStateContext& context) {
     if (context.isManualFlushStopRequested()) {
         context.setManualFlushStopRequested(false);
+        // Return to backflush idle since manual flush is only available from backflush mode
+        if (context.isBackflushModeActive()) {
+            context.logStateTransition(getStateId(), MachineStateId::BACKFLUSH_IDLE, "Manual flush stop requested");
+            return MachineStateId::BACKFLUSH_IDLE;
+        }
         return transitionToPidState(context, "Manual flush stop requested");
-    }
-    if (!context.isManualFlushActive()) {
-        return transitionToPidState(context, "Manual flush deactivated");
     }
     return std::nullopt;
 }

--- a/test/ZACwire.h
+++ b/test/ZACwire.h
@@ -1,15 +1,40 @@
 /**
  * @file ZACwire.h
- * @brief ZACwire stub for native test environment
+ * @brief Controllable ZACwire stub for native test environment
  */
 
 #pragma once
 
-// Minimal ZACwire stub
+#include <deque>
+
+// Controllable ZACwire stub. Tests queue readings via setNext(); getTemp() pops
+// the next queued value (or returns the steady value() if the queue is empty).
 class ZACwire {
 public:
-    ZACwire(int pin) {}
+    ZACwire(int /*pin*/, int /*sensorType*/ = 306) {}
     bool begin() { return true; }
-    float getTemp() { return 0.0f; }
+    float getTemp(int /*maxChangeRate*/ = 1) {
+        if (!queue().empty()) {
+            const float v = queue().front();
+            queue().pop_front();
+            return v;
+        }
+        return value();
+    }
     bool available() { return true; }
+
+    // --- Test controls ---
+    static float& value() {
+        static float v = 0.0f;
+        return v;
+    }
+    static std::deque<float>& queue() {
+        static std::deque<float> q;
+        return q;
+    }
+    static void reset() {
+        value() = 0.0f;
+        queue().clear();
+    }
+    static void setNext(float v) { queue().push_back(v); }
 };

--- a/test/mocks/HandlerTestStubs.cpp
+++ b/test/mocks/HandlerTestStubs.cpp
@@ -42,6 +42,21 @@ GPIOPin& Relay::getGPIOInstance() const noexcept { return gpio; }
 
 // === HardwareManager stubs ===
 namespace CleverCoffee {
+
+namespace TestHardwareSpy {
+inline int disablePumpCalls     = 0;
+inline int openWaterValveCalls  = 0;
+inline int enablePumpCalls      = 0;
+inline int closeWaterValveCalls = 0;
+
+inline void reset() noexcept {
+    disablePumpCalls    = 0;
+    openWaterValveCalls = 0;
+    enablePumpCalls     = 0;
+    closeWaterValveCalls = 0;
+}
+} // namespace TestHardwareSpy
+
 HardwareManager::HardwareManager(const Config& config)
     : config_(config),
       heaterRelayPin_(0, GPIOPin::OUT),
@@ -66,17 +81,27 @@ void HardwareManager::updateHardware() noexcept {}
 void HardwareManager::enableHeater() noexcept {}
 void HardwareManager::disableHeater() noexcept {}
 void HardwareManager::setHeaterPower(uint8_t) noexcept {}
-void HardwareManager::enablePump() noexcept {}
-void HardwareManager::disablePump() noexcept {}
+void HardwareManager::enablePump() noexcept {
+    TestHardwareSpy::enablePumpCalls++;
+}
+void HardwareManager::disablePump() noexcept {
+    TestHardwareSpy::disablePumpCalls++;
+}
 void HardwareManager::setPumpPressure(float) noexcept {}
 void HardwareManager::updateValveRelay() noexcept {}
 void HardwareManager::openSteamValve() noexcept {}
 void HardwareManager::closeSteamValve() noexcept {}
-void HardwareManager::openWaterValve() noexcept {}
-void HardwareManager::closeWaterValve() noexcept {}
+void HardwareManager::openWaterValve() noexcept {
+    TestHardwareSpy::openWaterValveCalls++;
+}
+void HardwareManager::closeWaterValve() noexcept {
+    TestHardwareSpy::closeWaterValveCalls++;
+}
 void HardwareManager::openSolenoid() noexcept {}
 void HardwareManager::closeSolenoid() noexcept {}
 void HardwareManager::emergencyShutdown() noexcept {}
+void HardwareManager::safeHardwareShutdown() noexcept {}
+void HardwareManager::clearEmergencyMode() noexcept {}
 void HardwareManager::updateSafetyState() noexcept {}
 void HardwareManager::cleanupPartialInit() noexcept {}
 Scale* HardwareManager::getScale() noexcept { return nullptr; }
@@ -97,12 +122,18 @@ int  MQTTManager::writeSysParamsToMQTT(bool) { return 0; }
 int  MQTTManager::sendHASSIODiscoveryMsg() { return 0; }
 
 // === ProcessController stub (PowerHandler calls performSafeShutdown) ===
+#include "clevercoffee/constants/Temperature.h"
 #include "clevercoffee/control/ProcessController.h"
 
 ProcessController::ProcessController(const Config& config, CleverCoffee::SystemContext& ctx,
                                      CleverCoffee::IHardwareContext& hw, IDisplayManager& disp, IMQTTManager& mqtt)
     : config_(config), systemContext_(ctx), hardwareManager_(hw), displayManager_(disp), mqttManager_(mqtt) {}
 void ProcessController::performSafeShutdown() {}
+void ProcessController::setTotalTargetBrewTime(double) {}
+void ProcessController::setCurrBrewTime(double) {}
+bool ProcessController::isEmergencyCleared(double temperature) const {
+    return temperature <= static_cast<double>(CleverCoffee::Temperature::EMERGENCY_SAFE_TEMP_C);
+}
 
 // === MachineStateContext constructor stub ===
 
@@ -159,7 +190,10 @@ bool MachineStateContext::isHotWaterActive() const { return false; }
 bool MachineStateContext::isBackflushActive() const { return false; }
 
 // System State Access
-bool MachineStateContext::isPidRuntimeEnabled() const { return Config::getInstance().pidEnabled.get(); }
+// Runtime PID is a transient flag (SystemContext), distinct from the persisted
+// config flag (Config). Modeling them separately lets tests exercise emergency/
+// standby recovery, where runtime is forced off then restored from config.
+bool MachineStateContext::isPidRuntimeEnabled() const { return systemContext_.isProcessPidEnabled(); }
 bool MachineStateContext::isPidConfigEnabled() const { return Config::getInstance().pidEnabled.get(); }
 bool          MachineStateContext::isEmergencyStop() const { return emergencyStop_; }
 bool          MachineStateContext::shouldEnterStandby() const { return false; }
@@ -178,8 +212,11 @@ void MachineStateContext::setHotWaterActivity(bool /*active*/) noexcept {}
 
 // Control Functions
 void MachineStateContext::setSteamMode(bool /*enabled*/) const {}
-void MachineStateContext::setPidRuntimeState(bool /*enabled*/) const {}
-void MachineStateContext::setUserPidEnabled(bool /*enabled*/) const {}
+void MachineStateContext::setPidRuntimeState(bool enabled) const { systemContext_.setProcessPidEnabled(enabled); }
+void MachineStateContext::setUserPidEnabled(bool enabled) const {
+    (void)Config::getInstance().pidEnabled.set(enabled);
+    systemContext_.setProcessPidEnabled(enabled);
+}
 void MachineStateContext::performSafeShutdown() const {}
 void MachineStateContext::setManualFlushState(bool /*active*/) const {}
 void MachineStateContext::setSteamState(bool active) { steamON_ = active; }
@@ -279,16 +316,26 @@ void   MachineStateContext::updateHardware() noexcept {}
 void   MachineStateContext::enableHeater() noexcept {}
 void   MachineStateContext::disableHeater() noexcept {}
 void   MachineStateContext::setHeaterPower(uint8_t /*percentage*/) noexcept {}
-void   MachineStateContext::enablePump() noexcept {}
-void   MachineStateContext::disablePump() noexcept {}
+void   MachineStateContext::enablePump() noexcept {
+    hardwareManager_.enablePump();
+}
+void   MachineStateContext::disablePump() noexcept {
+    hardwareManager_.disablePump();
+}
 void   MachineStateContext::setPumpPressure(float /*bar*/) noexcept {}
 void   MachineStateContext::openSteamValve() noexcept {}
 void   MachineStateContext::closeSteamValve() noexcept {}
-void   MachineStateContext::openWaterValve() noexcept {}
-void   MachineStateContext::closeWaterValve() noexcept {}
+void   MachineStateContext::openWaterValve() noexcept {
+    hardwareManager_.openWaterValve();
+}
+void   MachineStateContext::closeWaterValve() noexcept {
+    hardwareManager_.closeWaterValve();
+}
 void   MachineStateContext::openSolenoid() noexcept {}
 void   MachineStateContext::closeSolenoid() noexcept {}
 void   MachineStateContext::emergencyShutdown() noexcept {}
+void   MachineStateContext::safeHardwareShutdown() noexcept {}
+void   MachineStateContext::clearEmergencyMode() noexcept {}
 
 // IConfigContext Interface Implementation
 double        MachineStateContext::getBrewSetpoint() const noexcept { return Config::getInstance().brewSetpoint.get(); }

--- a/test/mocks/MockHardwareManager.h
+++ b/test/mocks/MockHardwareManager.h
@@ -84,6 +84,8 @@ public:
     MOCK_METHOD(void, closeSolenoid, (), (noexcept, override));
     
     MOCK_METHOD(void, emergencyShutdown, (), (noexcept, override));
+    MOCK_METHOD(void, safeHardwareShutdown, (), (noexcept, override));
+    MOCK_METHOD(void, clearEmergencyMode, (), (noexcept, override));
 };
 
 } // namespace CleverCoffee

--- a/test/test_brew_preinfusion_pause/test_main.cpp
+++ b/test/test_brew_preinfusion_pause/test_main.cpp
@@ -1,0 +1,79 @@
+/**
+ * @file test_main.cpp
+ * @brief Preinfusion pause keeps valve open and pump off
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "../ConfigTestHelper.h"
+#include "../test_support.h"
+#include "../mocks/MockWiFiManager.h"
+#include "../mocks/HandlerTestStubs.cpp"
+
+#include "clevercoffee/hardware/HardwareManager.h"
+#include "clevercoffee/state/states/BrewStates.h"
+
+const char* getStateName(MachineStateId) {
+    return "test";
+}
+
+#include "../../src/state/states/BrewStates.cpp"
+
+using ::testing::NiceMock;
+
+class BrewPreinfusionPauseTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        CleverCoffee::TestHardwareSpy::reset();
+        systemContext_ = std::make_unique<CleverCoffee::SystemContext>();
+        systemContext_->markReady();
+
+        dummyHwManager_      = std::make_unique<CleverCoffee::HardwareManager>(Config::getInstance());
+        dummyDisplayManager_ = std::make_unique<DisplayManager>(::Hardware::OLEDType::SSD1306,
+                                                                ::Hardware::OLEDAddress::ADDR_3C);
+        dummyMqttManager_    = std::make_unique<MQTTManager>();
+        dummyWiFiManager_    = std::make_unique<NiceMock<MockWiFiManager>>();
+
+        machineStateContext_ = std::make_unique<MachineStateContext>(
+            *systemContext_, *dummyHwManager_, *dummyDisplayManager_, *dummyWiFiManager_, *dummyMqttManager_);
+        systemContext_->setMachineStateContext(machineStateContext_.get());
+    }
+
+    void TearDown() override {
+        systemContext_->setMachineStateContext(nullptr);
+        machineStateContext_.reset();
+        dummyWiFiManager_.reset();
+        dummyMqttManager_.reset();
+        dummyDisplayManager_.reset();
+        dummyHwManager_.reset();
+        systemContext_.reset();
+        resetConfigDefaults();
+    }
+
+    std::unique_ptr<CleverCoffee::SystemContext>  systemContext_;
+    std::unique_ptr<MachineStateContext>          machineStateContext_;
+    std::unique_ptr<CleverCoffee::HardwareManager> dummyHwManager_;
+    std::unique_ptr<DisplayManager>               dummyDisplayManager_;
+    std::unique_ptr<MQTTManager>                  dummyMqttManager_;
+    std::unique_ptr<NiceMock<MockWiFiManager>>    dummyWiFiManager_;
+};
+
+TEST_F(BrewPreinfusionPauseTest, PauseEntryStopsPumpAndOpensValve) {
+    BrewPreinfusionPauseState state;
+    state.onEntry(*machineStateContext_);
+
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::openWaterValveCalls, 1);
+    EXPECT_EQ(CleverCoffee::TestHardwareSpy::enablePumpCalls, 0);
+}
+
+TEST_F(BrewPreinfusionPauseTest, PauseUpdateKeepsPumpOffAndValveOpen) {
+    BrewPreinfusionPauseState state;
+    state.update(*machineStateContext_);
+
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::openWaterValveCalls, 1);
+    EXPECT_EQ(CleverCoffee::TestHardwareSpy::enablePumpCalls, 0);
+}

--- a/test/test_process_controller/test_main.cpp
+++ b/test/test_process_controller/test_main.cpp
@@ -305,4 +305,41 @@ TEST_F(ProcessControllerIntegrationTest, PIDDisabledForDisabledState) {
     EXPECT_FALSE(shouldEnable) << "PID should be disabled in PID_DISABLED state";
 }
 
+// ============================================================================
+// BUG FIX: Safe shutdown must NOT enter emergency mode (Bug #2)
+// After PowerHandler calls performSafeShutdown, hardware must remain usable.
+// Root cause was: performSafeShutdown() called emergencyShutdown() which set
+// emergencyMode_=true permanently, blocking all subsequent hardware ops.
+// ============================================================================
+
+/**
+ * TEST: performSafeShutdown calls safeHardwareShutdown (not emergencyShutdown)
+ *
+ * Verifies the bug fix: normal power-off must NOT set emergencyMode_.
+ * If emergencyShutdown() were called, pump/valve would be permanently blocked.
+ */
+TEST_F(ProcessControllerIntegrationTest, SafeShutdownDoesNotCallEmergencyShutdown) {
+    controller_->initialize();
+
+    EXPECT_CALL(mockHardwareManager_, emergencyShutdown()).Times(0);
+    EXPECT_CALL(mockHardwareManager_, safeHardwareShutdown()).Times(1);
+
+    controller_->performSafeShutdown();
+}
+
+/**
+ * TEST: clearEmergencyMode is NOT called during safe shutdown
+ *
+ * clearEmergencyMode() is reserved for clearing real emergencies.
+ * performSafeShutdown() must not call it — the machine was never in emergency mode.
+ */
+TEST_F(ProcessControllerIntegrationTest, ClearEmergencyModeNotCalledDuringSafeShutdown) {
+    controller_->initialize();
+
+    EXPECT_CALL(mockHardwareManager_, clearEmergencyMode()).Times(0);
+    EXPECT_CALL(mockHardwareManager_, safeHardwareShutdown()).Times(1);
+
+    controller_->performSafeShutdown();
+}
+
 // Note: main() is provided by test/main.cpp

--- a/test/test_sensor_error_state/test_main.cpp
+++ b/test/test_sensor_error_state/test_main.cpp
@@ -1,0 +1,176 @@
+/**
+ * @file test_main.cpp
+ * @brief Unit tests for SensorErrorState transitions
+ *
+ * Regression tests for Bug #1:
+ * - SensorErrorState must NOT spontaneously transition to PID_DISABLED after a timeout.
+ * - SensorErrorState recovers back to the appropriate PID state when the error clears.
+ */
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <memory>
+
+#include "../ConfigTestHelper.h"
+#include "../test_support.h"
+#include "../mocks/MockWiFiManager.h"
+#include "../mocks/HandlerTestStubs.cpp"
+
+#include "clevercoffee/state/MachineStateIds.h"
+#include "clevercoffee/state/states/ErrorStates.h"
+
+const char* getStateName(MachineStateId) {
+    return "test";
+}
+
+#include "../../src/state/states/ErrorStates.cpp"
+
+using ::testing::NiceMock;
+
+// ============================================================================
+// TEST FIXTURE
+// ============================================================================
+
+class SensorErrorStateTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        g_test_millis = 0;
+        Preferences::resetTestStore();
+
+        systemContext_ = std::make_unique<CleverCoffee::SystemContext>();
+        systemContext_->markReady();
+
+        hwManager_      = std::make_unique<CleverCoffee::HardwareManager>(Config::getInstance());
+        displayManager_ = std::make_unique<DisplayManager>(::Hardware::OLEDType::SSD1306,
+                                                            ::Hardware::OLEDAddress::ADDR_3C);
+        mqttManager_    = std::make_unique<MQTTManager>();
+        wifiManager_    = std::make_unique<NiceMock<MockWiFiManager>>();
+
+        context_ = std::make_unique<MachineStateContext>(
+            *systemContext_, *hwManager_, *displayManager_, *wifiManager_, *mqttManager_);
+        systemContext_->setMachineStateContext(context_.get());
+
+        context_->updateStateEntryTime(std::chrono::steady_clock::now());
+    }
+
+    void TearDown() override {
+        systemContext_->setMachineStateContext(nullptr);
+        context_.reset();
+        hwManager_.reset();
+        displayManager_.reset();
+        mqttManager_.reset();
+        wifiManager_.reset();
+        systemContext_.reset();
+        g_test_millis = 0;
+    }
+
+    std::unique_ptr<CleverCoffee::SystemContext>  systemContext_;
+    std::unique_ptr<CleverCoffee::HardwareManager> hwManager_;
+    std::unique_ptr<DisplayManager>               displayManager_;
+    std::unique_ptr<MQTTManager>                  mqttManager_;
+    std::unique_ptr<NiceMock<MockWiFiManager>>    wifiManager_;
+    std::unique_ptr<MachineStateContext>           context_;
+};
+
+// ============================================================================
+// REGRESSION: Bug #1 — Spontaneous PID_DISABLED after sensor error
+// ============================================================================
+
+/**
+ * SensorErrorState must never transition to PID_DISABLED due to a timeout.
+ *
+ * The original bug: a 60-second timeout silently transitioned the machine to
+ * PID_DISABLED without any user action. This caused confusion because the
+ * display showed "PID disabled" after an unrelated sensor glitch.
+ *
+ * With the fix and PID enabled in config: after any amount of time spent in
+ * SENSOR_ERROR, the state either stays (if error still present) or recovers
+ * to PID_NORMAL. It must NEVER end up in PID_DISABLED unless the user
+ * had explicitly disabled PID.
+ */
+TEST_F(SensorErrorStateTest, NeverTransitionsToPidDisabledOnTimeout) {
+    // User has PID enabled — no reason for PID_DISABLED to appear
+    ASSERT_TRUE(Config::getInstance().pidEnabled.set(true));
+
+    SensorErrorState state;
+    state.onEntryImpl(*context_);
+
+    // Simulate far past the old 60-second timeout and past ERROR_RECOVERY_DELAY_MS
+    g_test_millis = 120'000UL;
+
+    auto next = state.checkSpecificTransitions(*context_);
+
+    // Must recover to PID_NORMAL, NOT PID_DISABLED
+    ASSERT_TRUE(next.has_value()) << "Should have transitioned after recovery delay";
+    EXPECT_NE(*next, MachineStateId::PID_DISABLED)
+        << "SensorErrorState must not transition to PID_DISABLED when user has PID enabled";
+    EXPECT_EQ(*next, MachineStateId::PID_NORMAL);
+}
+
+/**
+ * SensorErrorState returns nullopt (stays put) while the error is still active.
+ *
+ * The stubs return hasSensorError()=false and hasTemperatureError()=false which
+ * triggers the recovery path. We test the persisting-error scenario by verifying
+ * that within the recovery delay window the state returns nullopt.
+ */
+TEST_F(SensorErrorStateTest, StaysInSensorErrorWithinRecoveryDelay) {
+    SensorErrorState state;
+    state.onEntryImpl(*context_);
+
+    // Less than ERROR_RECOVERY_DELAY_MS (2000ms) — still in recovery delay window
+    g_test_millis = 500UL;
+
+    auto next = state.checkSpecificTransitions(*context_);
+
+    EXPECT_FALSE(next.has_value())
+        << "SensorErrorState should not transition before recovery delay expires";
+}
+
+/**
+ * SensorErrorState recovers to PID_NORMAL after the error clears and the
+ * recovery delay elapses.
+ *
+ * Stubs: hasSensorError()=false, hasTemperatureError()=false, pidEnabled=true
+ */
+TEST_F(SensorErrorStateTest, RecoversToPidNormalAfterDelayWhenErrorClears) {
+    // Ensure PID is enabled in config so getPidState() returns PID_NORMAL
+    ASSERT_TRUE(Config::getInstance().pidEnabled.set(true));
+
+    SensorErrorState state;
+    state.onEntryImpl(*context_);
+
+    // Jump past ERROR_RECOVERY_DELAY_MS (5000ms)
+    g_test_millis = 6000UL;
+
+    auto next = state.checkSpecificTransitions(*context_);
+
+    ASSERT_TRUE(next.has_value()) << "SensorErrorState should transition when error cleared and delay elapsed";
+    EXPECT_NE(*next, MachineStateId::PID_DISABLED)
+        << "SensorErrorState must not recover into PID_DISABLED";
+    EXPECT_EQ(*next, MachineStateId::PID_NORMAL)
+        << "SensorErrorState should recover to PID_NORMAL when PID is enabled";
+}
+
+/**
+ * SensorErrorState recovers to PID_DISABLED (not PID_NORMAL) when the user
+ * had explicitly disabled PID before the sensor error occurred.
+ */
+TEST_F(SensorErrorStateTest, RecoversToPidDisabledWhenUserHadDisabledPid) {
+    // User had disabled PID
+    ASSERT_TRUE(Config::getInstance().pidEnabled.set(false));
+
+    SensorErrorState state;
+    state.onEntryImpl(*context_);
+
+    g_test_millis = 6000UL;
+
+    auto next = state.checkSpecificTransitions(*context_);
+
+    ASSERT_TRUE(next.has_value());
+    EXPECT_EQ(*next, MachineStateId::PID_DISABLED)
+        << "Should recover to PID_DISABLED when user had disabled PID";
+}
+
+// Note: main() is provided by test/main.cpp

--- a/test/test_state_flow_integration/test_main.cpp
+++ b/test/test_state_flow_integration/test_main.cpp
@@ -1,0 +1,587 @@
+/**
+ * @file test_main.cpp
+ * @brief State flow integration tests: full end-to-end state transitions with hardware verification
+ *
+ * Tests complete state flows through the machine state machine, verifying hardware
+ * calls (pump, valve) at each transition point. Uses TestHardwareSpy to track calls.
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "../ConfigTestHelper.h"
+#include "../test_support.h"
+#include "../mocks/MockWiFiManager.h"
+#include "../mocks/HandlerTestStubs.cpp"
+
+#include "clevercoffee/hardware/HardwareManager.h"
+#include "clevercoffee/state/states/BrewStates.h"
+#include "clevercoffee/state/states/EmergencyStopState.h"
+#include "clevercoffee/state/states/InitState.h"
+#include "clevercoffee/state/states/PidStates.h"
+#include "clevercoffee/state/states/ErrorStates.h"
+#include "clevercoffee/state/states/SystemStates.h"
+
+const char* getStateName(MachineStateId) {
+    return "test";
+}
+
+#include "../../src/state/states/EmergencyStopState.cpp"
+#include "../../src/state/states/InitState.cpp"
+#include "../../src/state/states/PidStates.cpp"
+#include "../../src/state/states/BrewStates.cpp"
+#include "../../src/state/states/ErrorStates.cpp"
+#include "../../src/state/states/SystemStates.cpp"
+
+using ::testing::NiceMock;
+
+class StateFlowIntegrationTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        CleverCoffee::TestHardwareSpy::reset();
+        systemContext_ = std::make_unique<CleverCoffee::SystemContext>();
+        systemContext_->markReady();
+
+        dummyHwManager_      = std::make_unique<CleverCoffee::HardwareManager>(Config::getInstance());
+        dummyDisplayManager_ = std::make_unique<DisplayManager>(::Hardware::OLEDType::SSD1306,
+                                                                ::Hardware::OLEDAddress::ADDR_3C);
+        dummyMqttManager_    = std::make_unique<MQTTManager>();
+        dummyWiFiManager_    = std::make_unique<NiceMock<MockWiFiManager>>();
+
+        machineStateContext_ = std::make_unique<MachineStateContext>(
+            *systemContext_, *dummyHwManager_, *dummyDisplayManager_, *dummyWiFiManager_, *dummyMqttManager_);
+        systemContext_->setMachineStateContext(machineStateContext_.get());
+    }
+
+    void TearDown() override {
+        systemContext_->setMachineStateContext(nullptr);
+        machineStateContext_.reset();
+        dummyWiFiManager_.reset();
+        dummyMqttManager_.reset();
+        dummyDisplayManager_.reset();
+        dummyHwManager_.reset();
+        systemContext_.reset();
+        resetConfigDefaults();
+    }
+
+    void configureAutomaticBrewWithPreinfusion() {
+        Config& config = Config::getInstance();
+        config.pidEnabled.set(true);
+        config.brewMode.set(Process::BrewMode::AUTOMATIC_BREW);
+        config.brewPreInfusionEnabled.set(true);
+        config.brewPreInfusionTime.set(3.0);
+        config.brewPreInfusionPause.set(2.0);
+        config.brewByTimeEnabled.set(true);
+        config.brewByTimeTargetTime.set(25.0);
+    }
+
+    void advanceStateTime(std::chrono::milliseconds duration) {
+        auto pastTime = std::chrono::steady_clock::now() - duration;
+        machineStateContext_->updateStateEntryTime(pastTime);
+    }
+
+    std::unique_ptr<CleverCoffee::SystemContext>   systemContext_;
+    std::unique_ptr<MachineStateContext>           machineStateContext_;
+    std::unique_ptr<CleverCoffee::HardwareManager> dummyHwManager_;
+    std::unique_ptr<DisplayManager>                dummyDisplayManager_;
+    std::unique_ptr<MQTTManager>                   dummyMqttManager_;
+    std::unique_ptr<NiceMock<MockWiFiManager>>     dummyWiFiManager_;
+};
+
+// =============================================================================
+// Flow 1: Complete brew cycle
+// PID_NORMAL → BREW_PREINFUSION → BREW_PREINFUSION_PAUSE → BREW_RUNNING →
+// BREW_FINISHED → PID_NORMAL
+// =============================================================================
+
+TEST_F(StateFlowIntegrationTest, CompletBrewCycle_FullFlow) {
+    configureAutomaticBrewWithPreinfusion();
+
+    // --- Step 1: PID_NORMAL with brew start request → transitions to BREW_PREINFUSION ---
+    PidNormalState pidNormal;
+    machineStateContext_->setBrewStartRequested(true);
+    auto transition = pidNormal.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::BREW_PREINFUSION);
+
+    // --- Step 2: BREW_PREINFUSION onEntry → pump enabled, valve open ---
+    CleverCoffee::TestHardwareSpy::reset();
+    BrewPreinfusionState brewPreinfusion;
+    brewPreinfusion.onEntry(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::enablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::openWaterValveCalls, 1);
+
+    // --- Step 3: Advance past preinfusion time (3s) → transitions to PAUSE ---
+    advanceStateTime(std::chrono::milliseconds(3100));
+    transition = brewPreinfusion.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::BREW_PREINFUSION_PAUSE);
+
+    // --- Step 4: BREW_PREINFUSION onExit → pump disabled (valve stays open) ---
+    CleverCoffee::TestHardwareSpy::reset();
+    brewPreinfusion.onExit(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_EQ(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 0);
+
+    // --- Step 5: BREW_PREINFUSION_PAUSE onEntry → pump disabled, valve open ---
+    CleverCoffee::TestHardwareSpy::reset();
+    BrewPreinfusionPauseState brewPause;
+    brewPause.onEntry(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::openWaterValveCalls, 1);
+    EXPECT_EQ(CleverCoffee::TestHardwareSpy::enablePumpCalls, 0);
+
+    // --- Step 6: Advance past pause time (2s) → transitions to BREW_RUNNING ---
+    advanceStateTime(std::chrono::milliseconds(2100));
+    transition = brewPause.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::BREW_RUNNING);
+
+    // --- Step 7: BREW_PREINFUSION_PAUSE onExit → pump disabled (valve stays open) ---
+    CleverCoffee::TestHardwareSpy::reset();
+    brewPause.onExit(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_EQ(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 0);
+
+    // --- Step 8: BREW_RUNNING onEntry → pump enabled, valve open ---
+    CleverCoffee::TestHardwareSpy::reset();
+    BrewRunningState brewRunning;
+    brewRunning.onEntry(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::enablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::openWaterValveCalls, 1);
+
+    // --- Step 9: Brew stop requested → transitions to BREW_FINISHED ---
+    machineStateContext_->setBrewStopRequested(true);
+    transition = brewRunning.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::BREW_FINISHED);
+
+    // --- Step 10: BREW_RUNNING onExit → pump disabled, valve CLOSED ---
+    CleverCoffee::TestHardwareSpy::reset();
+    brewRunning.onExit(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 1);
+
+    // --- Step 11: BREW_FINISHED onEntry → no pump/valve changes ---
+    CleverCoffee::TestHardwareSpy::reset();
+    BrewFinishedState brewFinished;
+    brewFinished.onEntry(*machineStateContext_);
+    EXPECT_EQ(CleverCoffee::TestHardwareSpy::enablePumpCalls, 0);
+    // Valve/pump may not be touched by onEntry
+
+    // --- Step 12: Advance past FINISHED_DISPLAY_TIMEOUT_MS → transitions to PID_NORMAL ---
+    advanceStateTime(std::chrono::milliseconds(3100));
+    transition = brewFinished.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::PID_NORMAL);
+}
+
+// =============================================================================
+// Flow 2: Brew abort during preinfusion pause
+// PID_NORMAL → BREW_PREINFUSION → BREW_PREINFUSION_PAUSE → (abort) → PID_NORMAL
+// =============================================================================
+
+TEST_F(StateFlowIntegrationTest, BrewAbortDuringPreinfusionPause) {
+    configureAutomaticBrewWithPreinfusion();
+
+    // Get into BREW_PREINFUSION_PAUSE state
+    BrewPreinfusionPauseState brewPause;
+    brewPause.onEntry(*machineStateContext_);
+    CleverCoffee::TestHardwareSpy::reset();
+
+    // User requests brew stop during pause
+    machineStateContext_->setBrewStopRequested(true);
+    auto transition = brewPause.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::PID_NORMAL);
+
+    // Verify onExit behavior: pump disabled but valve NOT closed
+    // (valve closure for abort from pause relies on valveSafetyShutdownCheck)
+    CleverCoffee::TestHardwareSpy::reset();
+    brewPause.onExit(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    // DOCUMENTING CURRENT BEHAVIOR: BrewPreinfusionPauseState::onExitImpl does NOT close valve.
+    // The valve remains open until valveSafetyShutdownCheck() runs externally.
+    EXPECT_EQ(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 0);
+}
+
+TEST_F(StateFlowIntegrationTest, BrewAbortDuringPreinfusion) {
+    configureAutomaticBrewWithPreinfusion();
+
+    // Enter preinfusion
+    BrewPreinfusionState brewPreinfusion;
+    brewPreinfusion.onEntry(*machineStateContext_);
+    CleverCoffee::TestHardwareSpy::reset();
+
+    // User requests brew stop during preinfusion
+    machineStateContext_->setBrewStopRequested(true);
+    auto transition = brewPreinfusion.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::PID_NORMAL);
+
+    // onExit: pump disabled, valve NOT closed (same pattern as pause)
+    CleverCoffee::TestHardwareSpy::reset();
+    brewPreinfusion.onExit(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_EQ(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 0);
+}
+
+// =============================================================================
+// Flow 3: PID toggle cycle
+// PID_NORMAL → PID_DISABLED → PID_NORMAL → brew works (regression test)
+// =============================================================================
+
+TEST_F(StateFlowIntegrationTest, PidToggleCycle_BrewWorksAfterReEnable) {
+    configureAutomaticBrewWithPreinfusion();
+
+    // --- Step 1: PID_NORMAL → isPidRuntimeEnabled becomes false → PID_DISABLED ---
+    PidNormalState pidNormal;
+    machineStateContext_->setUserPidEnabled(false);
+    auto transition = pidNormal.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::PID_DISABLED);
+
+    // --- Step 2: PID_DISABLED onEntry → pump disabled, valve closed ---
+    CleverCoffee::TestHardwareSpy::reset();
+    PidDisabledState pidDisabled;
+    pidDisabled.onEntry(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 1);
+
+    // --- Step 3: Re-enable PID → transitions back to PID_NORMAL ---
+    machineStateContext_->setUserPidEnabled(true);
+    transition = pidDisabled.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::PID_NORMAL);
+
+    // --- Step 4: PID_NORMAL → brew start → BREW_PREINFUSION (regression: pump must work) ---
+    PidNormalState pidNormal2;
+    machineStateContext_->setBrewStartRequested(true);
+    transition = pidNormal2.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::BREW_PREINFUSION);
+
+    // --- Step 5: Verify pump actually enables on preinfusion entry ---
+    CleverCoffee::TestHardwareSpy::reset();
+    BrewPreinfusionState brewPreinfusion;
+    brewPreinfusion.onEntry(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::enablePumpCalls, 1)
+        << "Regression: pump must enable after PID toggle cycle";
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::openWaterValveCalls, 1)
+        << "Regression: valve must open after PID toggle cycle";
+}
+
+// =============================================================================
+// Flow 4: Emergency during brew
+// BREW_RUNNING → (emergency) → EMERGENCY_STOP (via BaseState::checkTransitions)
+// =============================================================================
+
+TEST_F(StateFlowIntegrationTest, EmergencyDuringBrew_HardwareCleanedUp) {
+    configureAutomaticBrewWithPreinfusion();
+
+    // Enter brew running state
+    BrewRunningState brewRunning;
+    brewRunning.onEntry(*machineStateContext_);
+    CleverCoffee::TestHardwareSpy::reset();
+
+    // Trigger emergency stop
+    machineStateContext_->setEmergencyStop(true);
+
+    // BaseState::checkTransitions detects emergency before checkSpecificTransitions
+    auto transition = brewRunning.checkTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::EMERGENCY_STOP);
+
+    // onExit is called by the state machine on transition → hardware cleanup
+    CleverCoffee::TestHardwareSpy::reset();
+    brewRunning.onExit(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 1);
+}
+
+TEST_F(StateFlowIntegrationTest, EmergencyDuringPreinfusion_Detected) {
+    configureAutomaticBrewWithPreinfusion();
+
+    BrewPreinfusionState brewPreinfusion;
+    brewPreinfusion.onEntry(*machineStateContext_);
+
+    machineStateContext_->setEmergencyStop(true);
+    auto transition = brewPreinfusion.checkTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::EMERGENCY_STOP);
+}
+
+// Regression: after a transient overtemperature trips emergency, recovery must
+// restore the runtime PID from config so the machine resumes heating instead of
+// getting stuck showing "PID is disabled manually".
+// EMERGENCY_STOP → (cleared) → INIT → PID_NORMAL
+TEST_F(StateFlowIntegrationTest, EmergencyRecovery_RestoresPidFromConfig) {
+    Config::getInstance().pidEnabled.set(true);
+
+    EmergencyStopState emergency;
+    emergency.onEntry(*machineStateContext_);
+    EXPECT_FALSE(machineStateContext_->isPidRuntimeEnabled());
+
+    // Temperature back to safe range (test sensor reads 0 °C; no ProcessController
+    // wired, so EmergencyStopState uses the fallback safe-temp threshold).
+    machineStateContext_->setEmergencyStop(false);
+
+    auto transition = emergency.checkTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::INIT);
+
+    // State machine calls onExit on transition → must re-enable runtime PID.
+    emergency.onExit(*machineStateContext_);
+    EXPECT_TRUE(machineStateContext_->isPidRuntimeEnabled());
+
+    // InitState now routes to PID_NORMAL, not PID_DISABLED.
+    InitState init;
+    auto      initTransition = init.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(initTransition.has_value());
+    EXPECT_EQ(initTransition.value(), MachineStateId::PID_NORMAL);
+}
+
+// When PID was disabled in config (user choice), emergency recovery must NOT
+// silently re-enable it — config remains the source of truth.
+TEST_F(StateFlowIntegrationTest, EmergencyRecovery_RespectsConfigPidDisabled) {
+    Config::getInstance().pidEnabled.set(false);
+
+    EmergencyStopState emergency;
+    emergency.onEntry(*machineStateContext_);
+    machineStateContext_->setEmergencyStop(false);
+
+    emergency.onExit(*machineStateContext_);
+    EXPECT_FALSE(machineStateContext_->isPidRuntimeEnabled());
+}
+
+// =============================================================================
+// Flow 5: Manual flush flow
+// PID_NORMAL → MANUAL_FLUSH_RUNNING → PID_NORMAL
+// =============================================================================
+
+TEST_F(StateFlowIntegrationTest, ManualFlushFlow_PumpAndValveControlled) {
+    Config::getInstance().pidEnabled.set(true);
+
+    // --- Step 1: PID_NORMAL → manual flush start → MANUAL_FLUSH_RUNNING ---
+    PidNormalState pidNormal;
+    machineStateContext_->setManualFlushStartRequested(true);
+    auto transition = pidNormal.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::MANUAL_FLUSH_RUNNING);
+
+    // --- Step 2: ManualFlushRunningState onEntry → pump enabled, valve open ---
+    CleverCoffee::TestHardwareSpy::reset();
+    ManualFlushRunningState manualFlush;
+    manualFlush.onEntry(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::enablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::openWaterValveCalls, 1);
+
+    // --- Step 3: Manual flush stop → transitions back to PID ---
+    machineStateContext_->setManualFlushStopRequested(true);
+    transition = manualFlush.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::PID_NORMAL);
+
+    // --- Step 4: onExit → pump disabled, valve closed ---
+    CleverCoffee::TestHardwareSpy::reset();
+    manualFlush.onExit(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 1);
+}
+
+TEST_F(StateFlowIntegrationTest, ManualFlush_UpdateKeepsPumpAndValveActive) {
+    Config::getInstance().pidEnabled.set(true);
+
+    ManualFlushRunningState manualFlush;
+    manualFlush.onEntry(*machineStateContext_);
+    CleverCoffee::TestHardwareSpy::reset();
+
+    // Update should maintain pump and valve state
+    manualFlush.update(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::enablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::openWaterValveCalls, 1);
+}
+
+// =============================================================================
+// Flow 6: Standby and wake
+// PID_NORMAL → STANDBY → PID_NORMAL
+// =============================================================================
+
+TEST_F(StateFlowIntegrationTest, StandbyAndWake_PidDisabledAndRestored) {
+    Config::getInstance().pidEnabled.set(true);
+
+    // --- Step 1: PID_NORMAL → standby requested → STANDBY ---
+    PidNormalState pidNormal;
+    machineStateContext_->setStandbyRequested(true);
+    auto transition = pidNormal.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::STANDBY);
+
+    // --- Step 2: Standby onEntry → pump disabled, valve closed ---
+    CleverCoffee::TestHardwareSpy::reset();
+    StandbyState standby;
+    standby.onEntry(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 1);
+
+    // --- Step 3: Normal operation requested → exits standby ---
+    machineStateContext_->setNormalOperationRequested(true);
+    transition = standby.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::PID_NORMAL);
+
+    // --- Step 4: StandbyState onExit → PID runtime restored ---
+    standby.onExit(*machineStateContext_);
+    // After exit, the PID state should be based on config (which is true)
+    EXPECT_TRUE(machineStateContext_->isPidRuntimeEnabled());
+}
+
+TEST_F(StateFlowIntegrationTest, StandbyWakeOnBrewRequest) {
+    Config::getInstance().pidEnabled.set(true);
+
+    StandbyState standby;
+    standby.onEntry(*machineStateContext_);
+
+    // Brew start request should wake from standby
+    machineStateContext_->setBrewStartRequested(true);
+    auto transition = standby.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::PID_NORMAL);
+}
+
+// =============================================================================
+// Additional edge cases
+// =============================================================================
+
+TEST_F(StateFlowIntegrationTest, BrewRunningOnExit_AlwaysClosesValve) {
+    // This is a critical safety test: BrewRunningState::onExit MUST close the valve
+    configureAutomaticBrewWithPreinfusion();
+
+    BrewRunningState brewRunning;
+    brewRunning.onEntry(*machineStateContext_);
+    CleverCoffee::TestHardwareSpy::reset();
+
+    brewRunning.onExit(*machineStateContext_);
+
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1)
+        << "Safety: pump must be disabled on brew exit";
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 1)
+        << "Safety: valve must be closed on brew exit";
+}
+
+TEST_F(StateFlowIntegrationTest, BrewFinishedOnExit_AlsoClosesValve) {
+    // BrewFinishedState::onExit also cleans up as a safety net
+    configureAutomaticBrewWithPreinfusion();
+
+    BrewFinishedState brewFinished;
+    brewFinished.onEntry(*machineStateContext_);
+    CleverCoffee::TestHardwareSpy::reset();
+
+    brewFinished.onExit(*machineStateContext_);
+
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 1);
+}
+
+TEST_F(StateFlowIntegrationTest, PidNormalToBrewManualMode_SkipsPreinfusion) {
+    Config::getInstance().pidEnabled.set(true);
+    Config::getInstance().brewMode.set(Process::BrewMode::MANUAL_BREW);
+
+    PidNormalState pidNormal;
+    machineStateContext_->setBrewStartRequested(true);
+    auto transition = pidNormal.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    // Manual mode goes directly to BREW_RUNNING
+    EXPECT_EQ(transition.value(), MachineStateId::BREW_RUNNING);
+}
+
+TEST_F(StateFlowIntegrationTest, PidDisabledDrainsActionRequests) {
+    machineStateContext_->setUserPidEnabled(false);
+
+    PidDisabledState pidDisabled;
+    pidDisabled.onEntry(*machineStateContext_);
+
+    // Set various requests that should be drained
+    machineStateContext_->setBrewStartRequested(true);
+    machineStateContext_->setManualFlushStartRequested(true);
+
+    // After update, the flags should be cleared (drained)
+    pidDisabled.update(*machineStateContext_);
+    EXPECT_FALSE(machineStateContext_->isBrewStartRequested());
+    EXPECT_FALSE(machineStateContext_->isManualFlushStartRequested());
+}
+
+TEST_F(StateFlowIntegrationTest, BrewPreinfusionToRunning_WhenPreinfusionDisabled) {
+    Config::getInstance().pidEnabled.set(true);
+    Config::getInstance().brewMode.set(Process::BrewMode::AUTOMATIC_BREW);
+    Config::getInstance().brewPreInfusionEnabled.set(false);
+
+    BrewPreinfusionState brewPreinfusion;
+    brewPreinfusion.onEntry(*machineStateContext_);
+
+    // With preinfusion disabled, should immediately transition to RUNNING
+    auto transition = brewPreinfusion.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::BREW_RUNNING);
+}
+
+TEST_F(StateFlowIntegrationTest, BrewPreinfusionToRunning_WhenPauseIsZero) {
+    Config::getInstance().pidEnabled.set(true);
+    Config::getInstance().brewMode.set(Process::BrewMode::AUTOMATIC_BREW);
+    Config::getInstance().brewPreInfusionEnabled.set(true);
+    Config::getInstance().brewPreInfusionTime.set(2.0);
+    Config::getInstance().brewPreInfusionPause.set(0.0);
+
+    BrewPreinfusionState brewPreinfusion;
+    brewPreinfusion.onEntry(*machineStateContext_);
+
+    // Advance past preinfusion time
+    advanceStateTime(std::chrono::milliseconds(2100));
+
+    // With pause=0, should skip pause and go directly to RUNNING
+    auto transition = brewPreinfusion.checkSpecificTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::BREW_RUNNING);
+}
+
+TEST_F(StateFlowIntegrationTest, EmergencyDuringManualFlush_DetectedByBaseState) {
+    Config::getInstance().pidEnabled.set(true);
+
+    ManualFlushRunningState manualFlush;
+    manualFlush.onEntry(*machineStateContext_);
+
+    machineStateContext_->setEmergencyStop(true);
+
+    // BaseState::checkTransitions handles emergency before specific transitions
+    auto transition = manualFlush.checkTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::EMERGENCY_STOP);
+
+    // onExit cleans up hardware
+    CleverCoffee::TestHardwareSpy::reset();
+    manualFlush.onExit(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 1);
+}
+
+TEST_F(StateFlowIntegrationTest, PidDisabledDuringBrew_ForcesTransition) {
+    configureAutomaticBrewWithPreinfusion();
+
+    BrewRunningState brewRunning;
+    brewRunning.onEntry(*machineStateContext_);
+
+    // Disable PID while brew is running
+    machineStateContext_->setUserPidEnabled(false);
+
+    // BaseState::checkTransitions forces PID_DISABLED for active operation states
+    auto transition = brewRunning.checkTransitions(*machineStateContext_);
+    ASSERT_TRUE(transition.has_value());
+    EXPECT_EQ(transition.value(), MachineStateId::PID_DISABLED);
+
+    // onExit cleans up
+    CleverCoffee::TestHardwareSpy::reset();
+    brewRunning.onExit(*machineStateContext_);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::disablePumpCalls, 1);
+    EXPECT_GE(CleverCoffee::TestHardwareSpy::closeWaterValveCalls, 1);
+}

--- a/test/test_temp_sensor_tsic/test_main.cpp
+++ b/test/test_temp_sensor_tsic/test_main.cpp
@@ -1,0 +1,100 @@
+/**
+ * @file test_main.cpp
+ * @brief Unit tests for TSIC temperature sensor glitch rejection and stabilisation
+ *
+ * Regression coverage for two field-observed bugs:
+ * 1. Out-of-range glitches (e.g. -2.9 °C) were passed through as valid readings,
+ *    tripping the emergency-stop invalid-reading path on a single sample.
+ * 2. tryGetValue() seeded the previous reading with 0.0, so the TSIC stabilisation
+ *    never latched — flooding the log with "Temperature not stable".
+ */
+
+#include <gtest/gtest.h>
+
+#include "../test_support.h"
+
+#include "clevercoffee/hardware/tempsensors/TempSensorTSIC.h"
+
+#include "../mocks/ConfigStubs.cpp"
+#include "../../src/Logger.cpp"
+#include "../../src/hardware/tempsensors/TempSensorTSIC.cpp"
+
+using namespace CleverCoffee;
+
+namespace {
+
+// Drive a single read cycle through the ISensor interface.
+Expected<double, Error> readOnce(TempSensorTSIC& sensor) {
+    sensor.startRead();
+    return sensor.tryGetValue();
+}
+
+} // namespace
+
+class TempSensorTSICTest : public ::testing::Test {
+  protected:
+    void SetUp() override { ZACwire::reset(); }
+};
+
+// A physically impossible reading must not surface as a valid value — it must be
+// reported as not-ready so the caller keeps the last good cached temperature and
+// the emergency-stop logic never sees the garbage value.
+TEST_F(TempSensorTSICTest, NegativeGlitchIsRejected) {
+    TempSensorTSIC sensor(4);
+
+    ZACwire::setNext(-2.9f);
+    auto result = readOnce(sensor);
+
+    EXPECT_FALSE(result.hasValue());
+}
+
+// Values above the sensor's physical range are likewise rejected.
+TEST_F(TempSensorTSICTest, OverRangeGlitchIsRejected) {
+    TempSensorTSIC sensor(4);
+
+    ZACwire::setNext(250.0f);
+    auto result = readOnce(sensor);
+
+    EXPECT_FALSE(result.hasValue());
+}
+
+// Sensor error codes continue to be treated as failed reads.
+TEST_F(TempSensorTSICTest, SensorErrorCodesAreRejected) {
+    TempSensorTSIC sensor(4);
+
+    ZACwire::setNext(222.0f); // read failed
+    EXPECT_FALSE(readOnce(sensor).hasValue());
+
+    ZACwire::setNext(221.0f); // not connected
+    EXPECT_FALSE(readOnce(sensor).hasValue());
+}
+
+// A normal in-range reading is returned unchanged.
+TEST_F(TempSensorTSICTest, ValidReadingIsReturned) {
+    TempSensorTSIC sensor(4);
+
+    ZACwire::setNext(94.0f);
+    auto result = readOnce(sensor);
+
+    ASSERT_TRUE(result.hasValue());
+    EXPECT_NEAR(result.value(), 94.0, 0.01);
+}
+
+// A glitch between two good readings must not corrupt the cached value: the bad
+// sample is dropped and the next good sample reads correctly.
+TEST_F(TempSensorTSICTest, GlitchBetweenGoodReadingsDoesNotPropagate) {
+    TempSensorTSIC sensor(4);
+
+    ZACwire::setNext(95.0f);
+    auto first = readOnce(sensor);
+    ASSERT_TRUE(first.hasValue());
+    EXPECT_NEAR(first.value(), 95.0, 0.01);
+
+    ZACwire::setNext(-2.9f);
+    EXPECT_FALSE(readOnce(sensor).hasValue());
+
+    ZACwire::setNext(95.2f);
+    auto third = readOnce(sensor);
+    ASSERT_TRUE(third.hasValue());
+    EXPECT_NEAR(third.value(), 95.2, 0.01);
+}


### PR DESCRIPTION
Correct valve and pump behavior across brew/preinfusion and state transitions; add disableAllHardware helper and hardware ADR. Fix pump-blocked-after-poweroff and PID restore after emergency stop. Reject TSIC out-of-range glitches without tripping emergency stop. Includes state-flow and sensor native tests plus integration checklist.