### PR TITLE
ci: fix PR firmware artifact names and format fallback

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -37,5 +37,7 @@ jobs:
       - name: Install PlatformIO
         run: pip install --upgrade platformio
 
+      - uses: jdx/mise-action@v3
+
       - name: Check clang-format
         run: pio run -e esp32_usb --target check-format

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Inject slug env
+        uses: rlespinasse/github-slug-action@v5
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -42,15 +45,13 @@ jobs:
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF#refs/tags/}"
-          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            VERSION="4.x.x-${{ github.head_ref }}"
+            ARTIFACT_SLUG="${GITHUB_REF_NAME_SLUG_URL}"
           else
-            VERSION="4.x.x-${GITHUB_REF_NAME}"
+            VERSION="4.x.x-${GITHUB_REF_POINT}"
+            ARTIFACT_SLUG="4-x-x-${GITHUB_REF_POINT_SLUG_URL}"
           fi
-          # upload-artifact rejects / \ : * ? " < > | in names
-          ARTIFACT_VERSION="$(printf '%s' "$VERSION" | tr '/:\\?*\"<>|' '-')"
           echo "CLEVERCOFFEE_VERSION=${VERSION}" >> "${GITHUB_ENV}"
-          echo "version=${ARTIFACT_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "version=${ARTIFACT_SLUG}" >> "${GITHUB_OUTPUT}"
 
       - name: Build firmware
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,16 +39,18 @@ jobs:
 
       - name: Set CLEVERCOFFEE_VERSION
         id: version
-        env:
-          GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             VERSION="${GITHUB_REF#refs/tags/}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            VERSION="4.x.x-${{ github.head_ref }}"
           else
             VERSION="4.x.x-${GITHUB_REF_NAME}"
           fi
+          # upload-artifact rejects / \ : * ? " < > | in names
+          ARTIFACT_VERSION="$(printf '%s' "$VERSION" | tr '/:\\?*\"<>|' '-')"
           echo "CLEVERCOFFEE_VERSION=${VERSION}" >> "${GITHUB_ENV}"
-          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "version=${ARTIFACT_VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: Build firmware
         run: |


### PR DESCRIPTION
## Summary
- Add [github-slug-action](https://github.com/rlespinasse/github-slug-action) so PR builds use `GITHUB_REF_POINT` (real branch) instead of `ref_name` (`31/merge`).
- Use `GITHUB_REF_POINT_SLUG_URL` / `GITHUB_REF_NAME_SLUG_URL` for firmware artifact names (safe for `upload-artifact`).
- Add `jdx/mise-action` to the format workflow when Docker is unavailable for clang-format.

## Context
Renovate PR builds were failing at firmware artifact upload because version strings contained `/`.

## Test plan
- [x] Verified on Renovate PR branches #31–#36 with the previous fix
- [ ] CI on this PR (build + format)