### PR TITLE
fix(build): create data dir before copy:dist

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "dev:ui": "pnpm --filter @clevercoffee/frontend dev",
     "dev:api": "pnpm --filter @clevercoffee/mock-server dev",
     "prepare-esp": "pnpm --filter @clevercoffee/frontend build && pnpm run copy:dist",
-    "copy:dist": "rimraf ../data/ui && mv packages/frontend/dist ../data/ui",
+    "copy:dist": "mkdir -p ../data && rimraf ../data/ui && mv packages/frontend/dist ../data/ui",
     "lint": "biome check .",
     "format": "biome check --write ."
   },


### PR DESCRIPTION
## Summary
- Add `mkdir -p ../data` to `copy:dist` so `buildfs` works on fresh CI checkouts
- `data/` is gitignored, so `mv` into `../data/ui` failed in the release pipeline

## Test plan
- [x] `pnpm prepare-esp` with `data/` removed
- [x] `pio run --target buildfs -e esp32_usb`
- [x] `pio test -e native_test`