### PR TITLE
feat: keep PID/heater enabled when water tank empty if configured

### DIFF
--- a/CONFIG_REFERENCE.md
+++ b/CONFIG_REFERENCE.md
@@ -312,6 +312,11 @@ For each LED type (status, brew, steam):
     - `1`: Normally closed
 - **Description**: Water tank sensor switch mode
 
+### `hardware.sensors.watertank.keep_heater_on_empty`
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: Keep the PID/heater active while the tank is reported empty. Only the external reservoir is protected by this sensor, not the boiler — enable only if you understand the boiler will not be protected from running dry independently of this sensor. The standby timeout still applies: if the tank stays empty past the configured standby time, the machine enters standby and the heater turns off, so the heater never runs unattended indefinitely.
+
 ## Switches
 
 For each switch type (brew, power, steam):

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -78,7 +78,34 @@ A single out-of-range TSIC sample must never trip emergency stop or flood the lo
 - [ ] If emergency does trigger (sustained overtemp/fault), recovery returns to
       `PID Normal` (state 20), not `PID disabled` — see ADR 0002 / emergency recovery fix
 
-## 9. Frontend (when `ui/` files changed)
+## 10. Water Tank Sensor, Pump Safety & MQTT/Home Assistant Export
+
+- [ ] With `hardware.sensors.watertank.enabled=true` and the sensor disconnected/dry,
+      the machine transitions to `Water Tank Empty` state and the pump refuses to
+      start (`Cannot enable pump - water tank is empty` in logs)
+- [ ] If the pump was running when the tank goes empty, it stops immediately
+      (`Water tank is empty - pump operations disabled` in logs)
+- [ ] With `hardware.sensors.watertank.keep_heater_on_empty=false` (default), the
+      heater/PID turns off when the tank goes empty
+- [ ] With `hardware.sensors.watertank.keep_heater_on_empty=true`, the heater/PID
+      continues to run (temperature keeps climbing toward setpoint) while the tank
+      is empty; brewing/hot water/backflush remain blocked (pump still can't run)
+- [ ] Refilling the tank logs `Water tank refilled - pump operations enabled` and
+      the machine returns to its previous PID state
+- [ ] With `keep_heater_on_empty=true` and standby enabled, leaving the tank empty
+      past the standby timeout moves the machine to `Standby` and turns the heater
+      off — the heater must never run unattended indefinitely
+- [ ] A standby request (power switch/MQTT) is honored while in `Water Tank Empty`
+- [ ] Removing the tank while the machine is in `Standby` does NOT wake it up
+      (it stays in standby with the heater off)
+- [ ] With a Home Assistant instance subscribed to the MQTT discovery prefix, a
+      "Water Tank" binary_sensor entity appears (wet when full, dry when empty)
+      after connecting with `hardware.sensors.watertank.enabled=true`
+- [ ] `mosquitto_sub -t '<prefix>/<hostname>/waterTankFull'` reports `ON` when full
+      and `OFF` when empty; the message is retained, so a fresh subscriber (or a
+      restarted Home Assistant) receives the current state immediately
+
+## 11. Frontend (when `ui/` files changed)
 
 Run from `ui/packages/frontend`:
 

--- a/docs/state-machine-architecture.md
+++ b/docs/state-machine-architecture.md
@@ -152,7 +152,7 @@ stateDiagram-v2
 | BACKFLUSH_FILLING | **ON** | **OPEN** | ACTIVE | Fill portafilter |
 | BACKFLUSH_FLUSHING | OFF | CLOSED | ACTIVE | Drain to drip tray |
 | BACKFLUSH_FINISHED | OFF | CLOSED | ACTIVE | All cycles done |
-| WATER_TANK_EMPTY | OFF | CLOSED | ACTIVE | Pump blocked by HardwareManager |
+| WATER_TANK_EMPTY | OFF | CLOSED | OFF‡ | Pump blocked by HardwareManager; ‡ ACTIVE if `hardware.sensors.watertank.keep_heater_on_empty` is set. Standby request and standby timeout still transition to STANDBY (heater off) so the heater never runs unattended indefinitely; an empty tank does not wake a machine already in STANDBY |
 | EMERGENCY_STOP | OFF | CLOSED | OFF | Full shutdown |
 | SENSOR_ERROR | OFF | CLOSED | OFF | Safe mode |
 | EEPROM_ERROR | OFF | CLOSED | OFF | Safe mode |

--- a/docs/state-machine-architecture.md
+++ b/docs/state-machine-architecture.md
@@ -204,7 +204,7 @@ flowchart TD
 
 ### HardwareManager guards (Layer 4)
 - `enablePump()` refuses if tank empty or emergency mode active
-- `updateSafetyState()` force-disables pump when tank empties mid-brew
+- `setWaterTankEmpty()` force-disables pump when tank empties mid-brew (pushed after `SensorCoordinator::update()`, before state machine and process control in `LoopManager`)
 - `emergencyShutdown()` kills pump, valve, and heater immediately
 
 ---

--- a/include/clevercoffee/Config.h
+++ b/include/clevercoffee/Config.h
@@ -1113,6 +1113,15 @@ class Config {
                                                                     "Electrical configuration of water tank sensor",
                                                                     getSwitchModeOptions()};
 
+    ParamDef<bool> hardwareSensorsWatertankKeepHeaterOnEmpty{
+        "hardware.sensors.watertank.keep_heater_on_empty",
+        false,
+        "Keep Heater On When Tank Empty",
+        4,
+        2423,
+        "Warning: keeps the PID/heater active even when the water tank is reported empty. "
+        "Only the external reservoir is protected by this sensor, not the boiler."};
+
     ParamDef<bool> hardwareSensorsScaleEnabled{
         "hardware.sensors.scale.enabled", false, "Enable Scale", 4, 2501, "Enable scale functionality"};
 

--- a/include/clevercoffee/Config.h
+++ b/include/clevercoffee/Config.h
@@ -1442,11 +1442,10 @@ class Config {
                                            [this]() { return systemContext_ && systemContext_->mqttManager() &&
     systemContext_->mqttManager()->isConnected(); }, StateParamDef<bool>::UpdateFrequency::FREQUENT};
 
-     StateParamDef<bool> stateWaterTank{"state.water_tank", "Water Tank Full", 6, 608,
-                                            "Water tank sensor status",
-                                            [this]() { return systemContext_ && systemContext_->machineStateContext() ?
-    systemContext_->machineStateContext()->isWaterTankFullState() : false; },
-                                            StateParamDef<bool>::UpdateFrequency::FREQUENT};
+    StateParamDef<bool> stateWaterTank{"state.water_tank", "Water Tank Full", 6, 608,
+                                       "Water tank sensor status",
+                                       [this]() { return systemContext_ &&
+    systemContext_->sensorCoordinator().isWaterTankFull(); }, StateParamDef<bool>::UpdateFrequency::FREQUENT};
 
     // === BREWING STATUS ===
     StateParamDef<double> stateBrewTime{"state.brew_time", "Current Brew Time", 7, 701,

--- a/include/clevercoffee/constants/Timing.h
+++ b/include/clevercoffee/constants/Timing.h
@@ -35,8 +35,7 @@ constexpr unsigned long SLOW_LOOP_THRESHOLD_MS         = 100;   ///< Threshold f
 constexpr unsigned int  PERFORMANCE_LOG_INTERVAL_LOOPS = 1000;  ///< Log performance stats every N loops
 
 // Loop manager timing constants
-constexpr unsigned long DISPLAY_REFRESH_INTERVAL_MS  = 100; ///< Display refresh interval
-constexpr unsigned long WATER_TANK_CHECK_INTERVAL_MS = 200; ///< Water tank sensor check interval
+constexpr unsigned long DISPLAY_REFRESH_INTERVAL_MS = 100; ///< Display refresh interval
 // Temperature sensor interval: 400ms (2.5Hz) matches DS18B20 11-bit conversion time (~380ms)
 // Optimization opportunity: Reduce to 200ms (5Hz) by using 10-bit resolution (~188ms conversion)
 // See SENSOR_OPTIMIZATION.md for details

--- a/include/clevercoffee/context/HardwareContext.h
+++ b/include/clevercoffee/context/HardwareContext.h
@@ -226,22 +226,6 @@ class HardwareContext {
         hotWaterSwitch_ = sw;
     }
 
-    /**
-     * @brief Get water tank sensor
-     * @return Pointer to water tank sensor (nullptr if not initialized)
-     */
-    Switch* waterTankSensor() const noexcept {
-        return waterTankSensor_;
-    }
-
-    /**
-     * @brief Register water tank sensor
-     * @param sensor Pointer to water tank sensor hardware
-     */
-    void setWaterTankSensor(Switch* sensor) noexcept {
-        waterTankSensor_ = sensor;
-    }
-
     // ========== LEDs and GPIO Pins ==========
 
     /**
@@ -357,11 +341,10 @@ class HardwareContext {
     bool                   isBluetoothScale_ = false;
 
     // Switches
-    Switch* brewSwitch_      = nullptr;
-    Switch* steamSwitch_     = nullptr;
-    Switch* powerSwitch_     = nullptr;
-    Switch* hotWaterSwitch_  = nullptr;
-    Switch* waterTankSensor_ = nullptr;
+    Switch* brewSwitch_     = nullptr;
+    Switch* steamSwitch_    = nullptr;
+    Switch* powerSwitch_    = nullptr;
+    Switch* hotWaterSwitch_ = nullptr;
 
     // LED GPIO pins
     GPIOPin* statusLedPin_ = nullptr;

--- a/include/clevercoffee/coordinators/SensorCoordinator.h
+++ b/include/clevercoffee/coordinators/SensorCoordinator.h
@@ -9,6 +9,7 @@
 #include "clevercoffee/sensors/ISensor.h"
 
 #include <atomic>
+#include <memory>
 
 // Forward declarations
 class Switch;
@@ -34,11 +35,10 @@ class SensorCoordinator {
      * @brief Constructor
      * @param tempSensor Temperature sensor implementing ISensor (can be nullptr)
      * @param scaleSensor Scale sensor implementing ISensor (can be nullptr)
-     * @param waterTankSensor Water tank level sensor (can be nullptr)
      */
-    SensorCoordinator(ISensor* tempSensor      = nullptr,
-                      ISensor* scaleSensor     = nullptr,
-                      Switch*  waterTankSensor = nullptr) noexcept;
+    SensorCoordinator(ISensor* tempSensor = nullptr, ISensor* scaleSensor = nullptr) noexcept;
+
+    ~SensorCoordinator();
 
     /**
      * @brief Update all sensor readings
@@ -65,11 +65,16 @@ class SensorCoordinator {
     }
 
     /**
-     * @brief Set water tank sensor (late injection)
-     * @param sensor Water tank level sensor (can be nullptr)
+     * @brief Take ownership of the water tank level sensor
+     * @param sensor Water tank sensor (nullptr clears the owned sensor)
      */
-    void setWaterTankSensor(Switch* sensor) noexcept {
-        waterTankSensor_ = sensor;
+    void setWaterTankSensor(std::unique_ptr<Switch> sensor) noexcept;
+
+    /**
+     * @brief Get the owned water tank sensor (non-owning)
+     */
+    [[nodiscard]] Switch* getWaterTankSensor() const noexcept {
+        return waterTankSensor_.get();
     }
 
     // === Temperature Sensor ===
@@ -228,9 +233,9 @@ class SensorCoordinator {
 
   private:
     // Sensor references (not owned)
-    ISensor* tempSensor_      = nullptr;
-    ISensor* scaleSensor_     = nullptr;
-    Switch*  waterTankSensor_ = nullptr;
+    ISensor*                tempSensor_  = nullptr;
+    ISensor*                scaleSensor_ = nullptr;
+    std::unique_ptr<Switch> waterTankSensor_;
 
     // Cached values
     double cachedTemperature_      = 0.0;
@@ -271,10 +276,6 @@ class SensorCoordinator {
     float inY_   = 0.0f;
     float inOld_ = 0.0f;
     float inSum_ = 0.0f;
-
-    // Water tank debouncing
-    int                  waterTankConsecutiveReads_ = 0;
-    static constexpr int WATER_TANK_READS_NEEDED    = 3;
 
     // Scale operating modes
     std::atomic<bool> scaleTareMode_{false};        ///< Scale tare (reset to zero) mode

--- a/include/clevercoffee/core/LoopManager.h
+++ b/include/clevercoffee/core/LoopManager.h
@@ -42,7 +42,7 @@ class WebServerManager;
  * - Coordinate main loop updates for all subsystems
  * - Manage timing-sensitive operations
  * - Handle LED status updates based on machine state
- * - Coordinate water tank monitoring
+ * - Push water tank state to HardwareManager after sensor reads
  * - Manage debug timing and performance monitoring
  * - Provide clean separation between loop coordination and business logic
  */
@@ -92,10 +92,11 @@ class LoopManager {
      *
      * Orchestrates updates for all subsystems in the correct order:
      * 1. Logger updates for remote logging connections
-     * 2. Water tank sensor monitoring
-     * 3. Process control (PID/temperature) updates
-     * 4. LED status updates based on machine state
-     * 5. Debug timing and performance monitoring
+     * 2. Sensor reads and water tank push to HardwareManager
+     * 3. Switches and standby management
+     * 4. State machine transitions
+     * 5. Process control (PID) and LED updates
+     * 6. Network, website, and display updates
      */
     void update();
 
@@ -106,14 +107,6 @@ class LoopManager {
      * brew LED (brewing state indicator), and steam LED (steam mode indicator).
      */
     void updateLEDs();
-
-    /**
-     * @brief Update water tank sensor monitoring
-     *
-     * Checks water tank level using timer-based monitoring system.
-     * Updates are performed every 200ms to avoid sensor noise.
-     */
-    void updateWaterTank();
 
     /**
      * @brief Update process control systems
@@ -208,7 +201,7 @@ class LoopManager {
 
   private:
     /**
-     * @brief Setup all timers (sensors, water tank, general)
+     * @brief Setup all timers (sensors, general)
      * @return true if setup successful
      */
     bool setupAllTimers();
@@ -220,7 +213,6 @@ class LoopManager {
     void updatePressureSensor();
     void updateScaleSensor();
     void updateBrewWeight();
-    void checkWaterTankLevel();
 
     /**
      * @brief Invoke all centralized sensor timers
@@ -239,7 +231,6 @@ class LoopManager {
     bool initialized_;
 
     // Centralized timer system for all sensors
-    std::unique_ptr<MillisecondTimer> waterTankTimer_;
     std::unique_ptr<MillisecondTimer> temperatureTimer_;
     std::unique_ptr<MillisecondTimer> pressureTimer_;
     std::unique_ptr<MillisecondTimer> scaleTimer_;

--- a/include/clevercoffee/hardware/HardwareManager.h
+++ b/include/clevercoffee/hardware/HardwareManager.h
@@ -85,12 +85,6 @@ class HardwareManager : public IHardwareContext {
     Switch* getHotWaterSwitch() const noexcept {
         return hotWaterSwitch_.get();
     }
-    Switch* getWaterTankSensor() noexcept {
-        return waterTankSensor_.get();
-    }
-    const Switch* getWaterTankSensor() const noexcept {
-        return waterTankSensor_.get();
-    }
 
     // Temperature sensor access
     TempSensor* getTempSensor() noexcept {
@@ -148,7 +142,6 @@ class HardwareManager : public IHardwareContext {
     bool   isWaterTankEmpty() const noexcept override;
     double getWeight() const noexcept override;
     void   tareScale() noexcept override;
-    void   updateHardware() noexcept override;
 
     // Heater Control
     void enableHeater() noexcept override;
@@ -191,10 +184,16 @@ class HardwareManager : public IHardwareContext {
     void safeHardwareShutdown() noexcept;
 
     /**
-     * @brief Update safety state from sensors
-     * Called periodically to check water tank status
+     * @brief Push the current water tank state into the hardware layer.
+     *
+     * Called from the main loop with the debounced reading from
+     * SensorCoordinator (the single source of truth for tank state).
+     * Immediately stops the pump if it's running and the tank just went
+     * empty.
+     *
+     * @param empty true if the tank is empty, false if it has water
      */
-    void updateSafetyState() noexcept;
+    void setWaterTankEmpty(bool empty) noexcept;
 
   private:
     /// @brief Internal helper: turns off all relays and resets state tracking.
@@ -266,7 +265,6 @@ class HardwareManager : public IHardwareContext {
     std::unique_ptr<Switch> brewSwitch_;
     std::unique_ptr<Switch> steamSwitch_;
     std::unique_ptr<Switch> hotWaterSwitch_;
-    std::unique_ptr<Switch> waterTankSensor_;
 
     // Temperature sensor (managed with smart pointer)
     std::unique_ptr<TempSensor> tempSensor_;

--- a/include/clevercoffee/hardware/LED.h
+++ b/include/clevercoffee/hardware/LED.h
@@ -27,6 +27,6 @@ class LED {
     virtual void turnOff()                              = 0;
     virtual void setColor(int red, int green, int blue) = 0;
     virtual void setBrightness(int value)               = 0;
-    virtual void setGPIOState(bool state);
-    virtual ~LED() = default;
+    virtual void setGPIOState(bool state)               = 0;
+    virtual ~LED()                                      = default;
 };

--- a/include/clevercoffee/network/MQTTManager.h
+++ b/include/clevercoffee/network/MQTTManager.h
@@ -152,6 +152,13 @@ class MQTTManager : public IMQTTManager {
     void registerSensor(const char* topic, std::function<double()> callback);
 
     /**
+     * @brief Register MQTT binary sensor callback
+     * @param topic MQTT topic name
+     * @param callback Function to get sensor state (true = ON, false = OFF)
+     */
+    void registerBinarySensor(const char* topic, std::function<bool()> callback);
+
+    /**
      * @brief Set update running flag
      * @param running Whether update is running
      */
@@ -230,10 +237,21 @@ class MQTTManager : public IMQTTManager {
 
     std::unordered_map<const char*, const char*, hash_cstr, equal_cstr> mqttVars_; ///< MQTT parameter mappings
     std::unordered_map<const char*, std::function<double()>, hash_cstr, equal_cstr>
-        mqttSensors_;                                                              ///< MQTT sensor callbacks
+        mqttSensors_;                                                              ///< MQTT numeric sensor callbacks
+    std::unordered_map<const char*, std::function<bool()>, hash_cstr, equal_cstr>
+        mqttBinarySensors_; ///< MQTT binary sensor callbacks (ON/OFF payloads)
 
     // Track last sent values to avoid duplicate MQTT messages (unordered_map for O(1) lookup)
     std::unordered_map<const char*, std::string, hash_cstr, equal_cstr> mqttLastSent_;
+
+    // Incremental publish state for writeSysParamsToMQTT() — persists across
+    // time-budget slices so publishing resumes where it left off. Cursors are
+    // initialized lazily on the first call, after all registrations are done.
+    int                                    publishPhase_        = 0; ///< 0 = vars, 1 = sensors, 2 = binary sensors
+    bool                                   publishCursorsValid_ = false;
+    decltype(mqttVars_)::iterator          mqttVarsIt_;
+    decltype(mqttSensors_)::iterator       mqttSensorsIt_;
+    decltype(mqttBinarySensors_)::iterator mqttBinarySensorsIt_;
 
     // Update management
     bool                           mqttUpdateRunning_;
@@ -307,6 +325,11 @@ class MQTTManager : public IMQTTManager {
                                          const String& displayName,
                                          const String& unit_of_measurement,
                                          const String& device_class);
+    DiscoveryObject generateBinarySensorDevice(const String& name,
+                                               const String& displayName,
+                                               const String& device_class,
+                                               const String& payload_on  = "ON",
+                                               const String& payload_off = "OFF");
     DiscoveryObject generateNumberDevice(const String& name,
                                          const String& displayName,
                                          int           min_value,

--- a/include/clevercoffee/state/BaseState.h
+++ b/include/clevercoffee/state/BaseState.h
@@ -147,9 +147,14 @@ std::optional<MachineStateId> BaseState<StateId, DerivedState>::checkTransitions
         return MachineStateId::SENSOR_ERROR;
     }
 
-    if (!context.isWaterTankFull()) {
-        context.logStateTransition(getStateId(), MachineStateId::WATER_TANK_EMPTY, "Water tank empty");
-        return MachineStateId::WATER_TANK_EMPTY;
+    // Water tank check — excluded: WATER_TANK_EMPTY (must reach its specific
+    // transitions to honor standby request/timeout while the tank stays empty)
+    // and STANDBY (heater already off; an empty tank must not wake the machine).
+    if constexpr (StateId != MachineStateId::WATER_TANK_EMPTY && StateId != MachineStateId::STANDBY) {
+        if (!context.isWaterTankFull()) {
+            context.logStateTransition(getStateId(), MachineStateId::WATER_TANK_EMPTY, "Water tank empty");
+            return MachineStateId::WATER_TANK_EMPTY;
+        }
     }
 
     // PID disable check — force transition for active operation states.

--- a/include/clevercoffee/state/IHardwareContext.h
+++ b/include/clevercoffee/state/IHardwareContext.h
@@ -110,20 +110,6 @@ class IHardwareContext {
      */
 
     /**
-     * @brief Get the water tank sensor switch
-     *
-     * @return Pointer to the water tank sensor, or nullptr if not available
-     */
-    virtual Switch* getWaterTankSensor() noexcept = 0;
-
-    /**
-     * @brief Get the water tank sensor switch (const overload)
-     *
-     * @return Const pointer to the water tank sensor, or nullptr if not available
-     */
-    virtual const Switch* getWaterTankSensor() const noexcept = 0;
-
-    /**
      * @brief Check if water tank is empty
      *
      * @return true if water tank is empty, false if water is available
@@ -199,21 +185,6 @@ class IHardwareContext {
      * Resets the scale to read zero with current load as baseline.
      */
     virtual void tareScale() noexcept = 0;
-
-    /** @} */
-
-    /**
-     * @name Hardware Operations
-     * @{
-     */
-
-    /**
-     * @brief Update all hardware components
-     *
-     * Should be called periodically to update hardware state.
-     * This may include reading sensors, updating outputs, etc.
-     */
-    virtual void updateHardware() noexcept = 0;
 
     /** @} */
 

--- a/include/clevercoffee/state/MachineStateContext.h
+++ b/include/clevercoffee/state/MachineStateContext.h
@@ -123,12 +123,6 @@ class MachineStateContext : public CleverCoffee::IHardwareContext,
     const TempSensor* getTempSensor() const noexcept override;
 
     /**
-     * @brief Get water tank sensor
-     */
-    Switch*       getWaterTankSensor() noexcept override;
-    const Switch* getWaterTankSensor() const noexcept override;
-
-    /**
      * @brief Get brew switch
      */
     Switch* getBrewSwitch() const;
@@ -449,20 +443,6 @@ class MachineStateContext : public CleverCoffee::IHardwareContext,
     }
 
     /**
-     * @brief Check if water tank is full
-     */
-    bool isWaterTankFullState() const noexcept {
-        return waterTankFull_;
-    }
-
-    /**
-     * @brief Set water tank full state
-     */
-    void setWaterTankFullState(bool full) noexcept {
-        waterTankFull_ = full;
-    }
-
-    /**
      * @brief Check if system is initialized
      */
     bool isSystemInitialized() const noexcept {
@@ -746,7 +726,6 @@ class MachineStateContext : public CleverCoffee::IHardwareContext,
     bool   isWaterTankEmpty() const noexcept override;
     double getWeight() const noexcept override;
     void   tareScale() noexcept override;
-    void   updateHardware() noexcept override;
 
     // High-level hardware control (delegated to HardwareManager)
     void enableHeater() noexcept override;
@@ -807,7 +786,6 @@ class MachineStateContext : public CleverCoffee::IHardwareContext,
     bool steamFirstON_        = false; ///< Steam activated for first time
     bool backflushOn_         = false; ///< Backflush mode active
     int  currBackflushCycles_ = 1;     ///< Current backflush cycle count
-    bool waterTankFull_       = true;  ///< Water tank full state
     bool systemInitialized_   = false; ///< System initialization complete
 
     // === State Transition Request Flags ===

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -553,6 +553,7 @@ std::vector<ConfigParamDef*> Config::getAllConfigParams() {
         &hardwareSensorsPressureEnabled,
         &hardwareSensorsWatertankEnabled,
         &hardwareSensorsWatertankMode,
+        &hardwareSensorsWatertankKeepHeaterOnEmpty,
         &hardwareSensorsScaleEnabled,
         &hardwareSensorsScaleSamples,
         &hardwareSensorsScaleType,

--- a/src/control/ProcessController.cpp
+++ b/src/control/ProcessController.cpp
@@ -244,8 +244,11 @@ void ProcessController::updateSetpoint(bool steamActive) {
 }
 
 bool ProcessController::shouldPIDBeEnabled(MachineStateId machineState) const {
+    const bool tankEmptyBlocksHeater =
+        machineState == MachineStateId::WATER_TANK_EMPTY && !config_.hardwareSensorsWatertankKeepHeaterOnEmpty.get();
+
     // PID should be disabled in these states
-    return !(machineState == MachineStateId::PID_DISABLED || machineState == MachineStateId::WATER_TANK_EMPTY ||
+    return !(machineState == MachineStateId::PID_DISABLED || tankEmptyBlocksHeater ||
              machineState == MachineStateId::SENSOR_ERROR || machineState == MachineStateId::EMERGENCY_STOP ||
              machineState == MachineStateId::EEPROM_ERROR || machineState == MachineStateId::STANDBY ||
              isBackflushState(machineState) || systemContext_.isProcessBrewPidDisabled());

--- a/src/coordinators/SensorCoordinator.cpp
+++ b/src/coordinators/SensorCoordinator.cpp
@@ -15,17 +15,20 @@
 
 namespace CleverCoffee {
 
-SensorCoordinator::SensorCoordinator(ISensor* tempSensor, ISensor* scaleSensor, Switch* waterTankSensor) noexcept
-    : tempSensor_(tempSensor), scaleSensor_(scaleSensor), waterTankSensor_(waterTankSensor) {
+SensorCoordinator::SensorCoordinator(ISensor* tempSensor, ISensor* scaleSensor) noexcept
+    : tempSensor_(tempSensor), scaleSensor_(scaleSensor) {
     if (tempSensor_) {
         LOG(INFO, "SensorCoordinator initialized with temperature sensor");
     }
     if (scaleSensor_) {
         LOG(INFO, "SensorCoordinator initialized with scale sensor");
     }
-    if (waterTankSensor_) {
-        LOG(INFO, "SensorCoordinator initialized with water tank sensor");
-    }
+}
+
+SensorCoordinator::~SensorCoordinator() = default;
+
+void SensorCoordinator::setWaterTankSensor(std::unique_ptr<Switch> sensor) noexcept {
+    waterTankSensor_ = std::move(sensor);
 }
 
 void SensorCoordinator::update() noexcept {
@@ -138,11 +141,9 @@ void SensorCoordinator::updateWaterTank() noexcept {
 
     if (isWaterDetected && !currentWaterTankState) {
         waterTankFull_.store(true, std::memory_order_relaxed);
-        waterTankConsecutiveReads_ = 0;
         LOG(INFO, "Water tank is full");
     } else if (!isWaterDetected && currentWaterTankState) {
         waterTankFull_.store(false, std::memory_order_relaxed);
-        waterTankConsecutiveReads_ = 0;
         LOG(INFO, "Water tank is empty");
     }
 }

--- a/src/core/LoopManager.cpp
+++ b/src/core/LoopManager.cpp
@@ -124,46 +124,18 @@ void LoopManager::update() {
         return;
     }
 
-    // 2. Hardware updates (water tank, process control, LEDs)
-    if (performanceMonitoringEnabled_) {
-        stepStart = millis();
-    }
-    updateWaterTank();
-    updateProcessControl();
-    updateLEDs();
-    if (performanceMonitoringEnabled_) {
-        hardwareTime = millis() - stepStart;
-    }
-
-    // 3. Network updates (WiFi/MQTT/OTA/WebServer)
-    if (performanceMonitoringEnabled_) {
-        stepStart = millis();
-    }
-    updateNetwork();
-    if (performanceMonitoringEnabled_) {
-        networkTime = millis() - stepStart;
-    }
-
-    // 4. Website data transmission
-    if (performanceMonitoringEnabled_) {
-        stepStart = millis();
-    }
-    updateWebsite();
-    if (performanceMonitoringEnabled_) {
-        websiteTime = millis() - stepStart;
-    }
-
-    // 5. Sensor updates
+    // 2. Sensor updates (before state/process so tank guards and PID react same loop)
     if (performanceMonitoringEnabled_) {
         stepStart = millis();
     }
     sensorCoordinator_.update();
+    hardwareManager_.setWaterTankEmpty(!sensorCoordinator_.isWaterTankFull());
     updateCentralizedSensorTimers();
     if (performanceMonitoringEnabled_) {
         sensorsTime = millis() - stepStart;
     }
 
-    // 6. Switches and standby management
+    // 3. Switches and standby management
     if (performanceMonitoringEnabled_) {
         stepStart = millis();
     }
@@ -172,13 +144,41 @@ void LoopManager::update() {
         switchesTime = millis() - stepStart;
     }
 
-    // 7. State machine updates
+    // 4. State machine updates
     if (performanceMonitoringEnabled_) {
         stepStart = millis();
     }
     updateStateMachine();
     if (performanceMonitoringEnabled_) {
         stateMachineTime = millis() - stepStart;
+    }
+
+    // 5. Process control and LEDs (after state reflects sensor input)
+    if (performanceMonitoringEnabled_) {
+        stepStart = millis();
+    }
+    updateProcessControl();
+    updateLEDs();
+    if (performanceMonitoringEnabled_) {
+        hardwareTime = millis() - stepStart;
+    }
+
+    // 6. Network updates (WiFi/MQTT/OTA/WebServer)
+    if (performanceMonitoringEnabled_) {
+        stepStart = millis();
+    }
+    updateNetwork();
+    if (performanceMonitoringEnabled_) {
+        networkTime = millis() - stepStart;
+    }
+
+    // 7. Website data transmission
+    if (performanceMonitoringEnabled_) {
+        stepStart = millis();
+    }
+    updateWebsite();
+    if (performanceMonitoringEnabled_) {
+        websiteTime = millis() - stepStart;
     }
 
     // 8. Display updates
@@ -275,15 +275,6 @@ void LoopManager::updateLEDs() {
     if (Config::getInstance().hardwareLedsSteamEnabled.get() && hardwareManager_.getSteamLed()) {
         isSteamState(machineState) ? hardwareManager_.getSteamLed()->turnOn()
                                    : hardwareManager_.getSteamLed()->turnOff();
-    }
-}
-
-void LoopManager::updateWaterTank() {
-    // Water tank monitoring is handled by the timer-based system
-    if (waterTankTimer_) {
-        (*waterTankTimer_)();
-    } else {
-        LOG(WARNING, "LoopManager: Water tank timer not initialized");
     }
 }
 
@@ -389,17 +380,7 @@ bool LoopManager::setupAllTimers() {
                                                                 std::chrono::milliseconds(DISPLAY_REFRESH_INTERVAL_MS));
         LOG(INFO, "LoopManager: General timers initialized");
 
-        // 2. Water tank monitoring timer
-        using CleverCoffee::Timing::WATER_TANK_CHECK_INTERVAL_MS;
-        waterTankTimer_ = std::make_unique<MillisecondTimer>(std::bind(&LoopManager::checkWaterTankLevel, this),
-                                                             std::chrono::milliseconds(WATER_TANK_CHECK_INTERVAL_MS));
-        if (!waterTankTimer_) {
-            LOG(ERROR, "LoopManager: Failed to create water tank timer");
-            return false;
-        }
-        LOG(INFO, "LoopManager: Water tank timer initialized (200ms interval)");
-
-        // 3. Centralized sensor timers
+        // 2. Centralized sensor timers
         using CleverCoffee::Timing::PRESSURE_SENSOR_INTERVAL_MS;
         using CleverCoffee::Timing::SCALE_SENSOR_INTERVAL_MS;
         using CleverCoffee::Timing::TEMPERATURE_SENSOR_INTERVAL_MS;
@@ -425,11 +406,6 @@ bool LoopManager::setupAllTimers() {
         LOGF(ERROR, "LoopManager: Exception creating timers: %s", e.what());
         return false;
     }
-}
-
-void LoopManager::checkWaterTankLevel() {
-    // SensorCoordinator auto-updates water tank sensor
-    // Water tank status is accessed via sensorCoordinator_.isWaterTankFull() directly
 }
 
 void LoopManager::updateTemperatureSensor() {

--- a/src/core/SystemInitializer.cpp
+++ b/src/core/SystemInitializer.cpp
@@ -793,6 +793,12 @@ void SystemInitializer::registerMQTTSensors() {
                                      [this] { return systemContext_->sensorCoordinator().getFilteredPressure(); });
     }
 
+    // Water tank sensor
+    if (Config::getInstance().hardwareSensorsWatertankEnabled.get()) {
+        mqttManager_->registerBinarySensor("waterTankFull",
+                                           [this] { return systemContext_->sensorCoordinator().isWaterTankFull(); });
+    }
+
     LOG(DEBUG, "MQTT sensors registered");
 }
 

--- a/src/core/SystemInitializer.cpp
+++ b/src/core/SystemInitializer.cpp
@@ -18,7 +18,11 @@
 #include "clevercoffee/handlers/HotWaterHandler.h"
 #include "clevercoffee/handlers/PowerHandler.h"
 #include "clevercoffee/handlers/SteamHandler.h"
+#include "clevercoffee/hardware/GPIOPin.h"
 #include "clevercoffee/hardware/HardwareManager.h" // Include before own header to resolve forward declaration
+#include "clevercoffee/hardware/IOSwitch.h"
+#include "clevercoffee/hardware/Switch.h"
+#include "clevercoffee/hardware/pinmapping.h"
 #include "clevercoffee/isr.h"
 #include "clevercoffee/network/CleverCoffeeWiFiManager.h"
 #include "clevercoffee/network/MQTTManager.h"
@@ -35,6 +39,7 @@
 #include <PID_v1.h>
 #include <WiFi.h>
 #include <Wire.h>
+#include <memory>
 
 // Forward declarations
 extern void initTimer1();
@@ -55,6 +60,19 @@ void otaPrepareHardware() noexcept {
 
 void otaRestoreHardware() noexcept {
     enableTimer1();
+}
+
+std::unique_ptr<Switch> createWaterTankSensor(const Config& config) {
+    if (!config.hardwareSensorsWatertankEnabled.get()) {
+        return nullptr;
+    }
+
+    yield(); // Prevent watchdog timeout
+    const auto          mode         = config.hardwareSensorsWatertankMode.get();
+    const auto          initialState = (mode == ::Hardware::SwitchMode::NORMALLY_OPEN) ? HIGH : LOW;
+    const GPIOPin::Type pinType =
+        (mode == ::Hardware::SwitchMode::NORMALLY_OPEN) ? GPIOPin::IN_PULLDOWN : GPIOPin::IN_PULLUP;
+    return std::make_unique<IOSwitch>(PIN_WATERTANKSENSOR, pinType, ::Hardware::SwitchType::TOGGLE, mode, initialState);
 }
 
 } // namespace
@@ -370,7 +388,6 @@ bool SystemInitializer::initializeHardware() {
         systemContext_->hardwareContext().setBrewSwitch(hardwareManager_->getBrewSwitch());
         systemContext_->hardwareContext().setHotWaterSwitch(hardwareManager_->getHotWaterSwitch());
         systemContext_->hardwareContext().setSteamSwitch(hardwareManager_->getSteamSwitch());
-        systemContext_->hardwareContext().setWaterTankSensor(hardwareManager_->getWaterTankSensor());
 
         systemContext_->hardwareContext().setTempSensor(hardwareManager_->getTempSensor());
 
@@ -555,18 +572,17 @@ bool SystemInitializer::initializeSensors() {
             return false;
         }
 
-        // Get sensor references from HardwareManager
-        TempSensor* tempSensorRef      = hardwareManager_ ? hardwareManager_->getTempSensor() : nullptr;
-        Switch*     waterTankSensorRef = hardwareManager_ ? hardwareManager_->getWaterTankSensor() : nullptr;
-
-        // Inject sensors into SensorCoordinator
+        // Inject temperature sensor from HardwareManager
+        TempSensor* tempSensorRef = hardwareManager_ ? hardwareManager_->getTempSensor() : nullptr;
         if (tempSensorRef) {
             coord->setTemperatureSensor(tempSensorRef);
             LOG(INFO, "Temperature sensor injected into SensorCoordinator");
         }
-        if (waterTankSensorRef) {
-            coord->setWaterTankSensor(waterTankSensorRef);
-            LOG(INFO, "Water tank sensor injected into SensorCoordinator");
+
+        const auto& config = Config::getInstance();
+        if (auto waterTankSensor = createWaterTankSensor(config)) {
+            coord->setWaterTankSensor(std::move(waterTankSensor));
+            LOG(INFO, "Water tank sensor initialized in SensorCoordinator");
         }
 
         // Update global temperature variable for compatibility

--- a/src/hardware/HardwareManager.cpp
+++ b/src/hardware/HardwareManager.cpp
@@ -174,18 +174,6 @@ void HardwareManager::initializeSwitches() {
         LOG(INFO, "Hot water switch initialized");
     }
 
-    // Initialize water tank sensor
-    if (config_.hardwareSensorsWatertankEnabled.get()) {
-        LOG(INFO, "Initializing water tank sensor...");
-        yield(); // Prevent watchdog timeout
-        const auto          mode         = config_.hardwareSensorsWatertankMode.get();
-        const auto          initialState = (mode == SwitchMode::NORMALLY_OPEN) ? HIGH : LOW;
-        const GPIOPin::Type pinType = (mode == SwitchMode::NORMALLY_OPEN) ? GPIOPin::IN_PULLDOWN : GPIOPin::IN_PULLUP;
-        waterTankSensor_ =
-            std::make_unique<IOSwitch>(PIN_WATERTANKSENSOR, pinType, SwitchType::TOGGLE, mode, initialState);
-        LOG(INFO, "Water tank sensor initialized");
-    }
-
     LOG(INFO, "Switches initialized successfully");
 }
 
@@ -284,11 +272,6 @@ double HardwareManager::getWeight() const noexcept {
 
 void HardwareManager::tareScale() noexcept {
     // TODO: Integrate with scale when available
-}
-
-void HardwareManager::updateHardware() noexcept {
-    // Update safety state based on sensors
-    updateSafetyState();
 }
 
 void HardwareManager::enableHeater() noexcept {
@@ -560,23 +543,20 @@ void HardwareManager::disableAllHardware() noexcept {
     solenoidOpen_ = false;
 }
 
-void HardwareManager::updateSafetyState() noexcept {
-    // Check water tank sensor
-    if (waterTankSensor_) {
-        const bool tankHasWater = waterTankSensor_->isPressed();
-        if (tankHasWater != !waterTankEmpty_) {
-            waterTankEmpty_ = !tankHasWater;
-            if (waterTankEmpty_) {
-                LOG(WARNING, "Water tank is empty - pump operations disabled");
-                // Immediately disable pump if running
-                if (pumpRelay_ && pumpEnabled_) {
-                    pumpRelay_->off();
-                    pumpEnabled_ = false;
-                }
-            } else {
-                LOG(INFO, "Water tank refilled - pump operations enabled");
-            }
+void HardwareManager::setWaterTankEmpty(bool empty) noexcept {
+    if (empty == waterTankEmpty_) {
+        return;
+    }
+    waterTankEmpty_ = empty;
+    if (empty) {
+        LOG(WARNING, "Water tank is empty - pump operations disabled");
+        // Immediately disable pump if running
+        if (pumpRelay_ && pumpEnabled_) {
+            pumpRelay_->off();
+            pumpEnabled_ = false;
         }
+    } else {
+        LOG(INFO, "Water tank refilled - pump operations enabled");
     }
 }
 
@@ -600,7 +580,6 @@ void HardwareManager::cleanupPartialInit() noexcept {
         LOG(INFO, "Cleaning up switches...");
         // Switches don't need physical cleanup, just release resources
         hotWaterSwitch_.reset();
-        waterTankSensor_.reset();
         steamSwitch_.reset();
         brewSwitch_.reset();
         powerSwitch_.reset();

--- a/src/network/MQTTManager.cpp
+++ b/src/network/MQTTManager.cpp
@@ -359,10 +359,17 @@ void MQTTManager::registerSensor(const char* topic, std::function<double()> call
     mqttSensors_[topic] = callback;
 }
 
+void MQTTManager::registerBinarySensor(const char* topic, std::function<bool()> callback) {
+    mqttBinarySensors_[topic] = callback;
+}
+
 int MQTTManager::writeSysParamsToMQTT(bool continueOnError) {
-    static auto mqttVarsIt    = mqttVars_.begin();
-    static auto mqttSensorsIt = mqttSensors_.begin();
-    static bool inSensors     = false;
+    if (!publishCursorsValid_) {
+        mqttVarsIt_          = mqttVars_.begin();
+        mqttSensorsIt_       = mqttSensors_.begin();
+        mqttBinarySensorsIt_ = mqttBinarySensors_.begin();
+        publishCursorsValid_ = true;
+    }
 
     if (!systemContext_ || !systemContext_->isReady()) {
         return 0;
@@ -384,7 +391,7 @@ int MQTTManager::writeSysParamsToMQTT(bool continueOnError) {
         return 0;
     }
 
-    if (!inSensors && mqttVarsIt == mqttVars_.begin()) {
+    if (publishPhase_ == 0 && mqttVarsIt_ == mqttVars_.begin()) {
         previousMillisMQTT_ = currentMillisMQTT;
         (void)publish("status", "online");
     }
@@ -397,10 +404,10 @@ int MQTTManager::writeSysParamsToMQTT(bool continueOnError) {
     auto& config     = Config::getInstance();
 
     // Process parameter mappings
-    if (!inSensors) {
-        while (mqttVarsIt != mqttVars_.end()) {
-            const char* mqttTopic   = mqttVarsIt->first;
-            const char* parameterId = mqttVarsIt->second;
+    if (publishPhase_ == 0) {
+        while (mqttVarsIt_ != mqttVars_.end()) {
+            const char* mqttTopic   = mqttVarsIt_->first;
+            const char* parameterId = mqttVarsIt_->second;
 
             bool paramFound = false;
 
@@ -427,7 +434,7 @@ int MQTTManager::writeSysParamsToMQTT(bool continueOnError) {
                             return 1;
                         }
                         LOGF(WARNING, "Parameter %s not found for MQTT topic %s, skipping", parameterId, mqttTopic);
-                        ++mqttVarsIt;
+                        ++mqttVarsIt_;
                         continue;
                     }
 
@@ -466,7 +473,7 @@ int MQTTManager::writeSysParamsToMQTT(bool continueOnError) {
                     return 1;
                 }
                 LOGF(WARNING, "Parameter %s not found for MQTT topic %s, skipping", parameterId, mqttTopic);
-                ++mqttVarsIt;
+                ++mqttVarsIt_;
                 continue;
             }
 
@@ -488,48 +495,107 @@ int MQTTManager::writeSysParamsToMQTT(bool continueOnError) {
                 }
             }
 
-            ++mqttVarsIt;
+            ++mqttVarsIt_;
 
             if (millis() - start >= timeBudget_) {
                 return 0;
             }
         }
 
-        mqttVarsIt = mqttVars_.begin();
-        inSensors  = true;
+        mqttVarsIt_   = mqttVars_.begin();
+        publishPhase_ = 1;
     }
 
-    // Process sensor callbacks
-    while (mqttSensorsIt != mqttSensors_.end()) {
-        const char* topic      = mqttSensorsIt->first;
-        const auto& sensorFunc = mqttSensorsIt->second;
-        std::string value      = number2string(sensorFunc());
+    // Process numeric sensor callbacks
+    if (publishPhase_ == 1) {
+        while (mqttSensorsIt_ != mqttSensors_.end()) {
+            const char* topic      = mqttSensorsIt_->first;
+            const auto& sensorFunc = mqttSensorsIt_->second;
+            std::string value      = number2string(sensorFunc());
 
-        if (mqttLastSent_[topic] != value) {
-            if (!publish(topic, value.c_str())) {
-                errorState = mqttClient_.state();
-                if (!continueOnError) {
-                    return errorState;
+            if (mqttLastSent_[topic] != value) {
+                if (!publish(topic, value.c_str())) {
+                    errorState = mqttClient_.state();
+                    if (!continueOnError) {
+                        return errorState;
+                    }
+                } else {
+                    mqttLastSent_[topic] = value;
                 }
-            } else {
-                mqttLastSent_[topic] = value;
+            }
+
+            ++mqttSensorsIt_;
+
+            if (millis() - start >= timeBudget_) {
+                return 0;
             }
         }
 
-        ++mqttSensorsIt;
-
-        if (millis() - start >= timeBudget_) {
-            return 0;
-        }
+        mqttSensorsIt_ = mqttSensors_.begin();
+        publishPhase_  = 2;
     }
 
-    mqttSensorsIt = mqttSensors_.begin();
-    inSensors     = false;
+    // Process binary sensor callbacks
+    if (publishPhase_ == 2) {
+        while (mqttBinarySensorsIt_ != mqttBinarySensors_.end()) {
+            const char* topic            = mqttBinarySensorsIt_->first;
+            const auto& binarySensorFunc = mqttBinarySensorsIt_->second;
+            const char* value            = binarySensorFunc() ? "ON" : "OFF";
+
+            if (mqttLastSent_[topic] != value) {
+                // Retained: binary state must survive broker/HA restarts — it may
+                // not change again for days, so a fresh subscriber would otherwise
+                // see "unknown" until the next transition.
+                if (!publish(topic, value, true)) {
+                    errorState = mqttClient_.state();
+                    if (!continueOnError) {
+                        return errorState;
+                    }
+                } else {
+                    mqttLastSent_[topic] = value;
+                }
+            }
+
+            ++mqttBinarySensorsIt_;
+
+            if (millis() - start >= timeBudget_) {
+                return 0;
+            }
+        }
+
+        mqttBinarySensorsIt_ = mqttBinarySensors_.begin();
+        publishPhase_        = 0;
+    }
 
     return 0;
 }
 
 // Home Assistant Discovery Implementation
+
+namespace {
+void populateDeviceMap(JsonDocument& deviceMapDoc, const String& hostname) {
+    deviceMapDoc["identifiers"]  = hostname;
+    deviceMapDoc["manufacturer"] = "CleverCoffee";
+    deviceMapDoc["name"]         = hostname;
+}
+
+void attachDeviceAndAvailability(JsonDocument& configDoc, JsonDocument& deviceMapDoc, const String& statusTopic) {
+    configDoc["payload_available"]     = "online";
+    configDoc["payload_not_available"] = "offline";
+    configDoc["availability_topic"]    = statusTopic;
+
+    auto deviceField = configDoc["device"].to<JsonObject>();
+    for (JsonPair keyValue : deviceMapDoc.as<JsonObject>()) {
+        deviceField[keyValue.key()] = keyValue.value();
+    }
+}
+
+String serializeDiscoveryJson(const JsonDocument& configDoc) {
+    String buffer;
+    serializeJson(configDoc, buffer);
+    return buffer;
+}
+} // namespace
 
 MQTTManager::DiscoveryObject MQTTManager::generateSwitchDevice(const String& name,
                                                                const String& displayName,
@@ -646,30 +712,47 @@ MQTTManager::DiscoveryObject MQTTManager::generateSensorDevice(const String& nam
     sensor_device.discovery_topic = SensorDiscoveryTopic + unique_id + "/" + name + "/config";
 
     JsonDocument deviceMapDoc;
-    deviceMapDoc["identifiers"]  = hostname_;
-    deviceMapDoc["manufacturer"] = "CleverCoffee";
-    deviceMapDoc["name"]         = hostname_;
+    populateDeviceMap(deviceMapDoc, hostname_);
 
     JsonDocument sensorConfigDoc;
-    sensorConfigDoc["name"]                  = displayName;
-    sensorConfigDoc["state_topic"]           = sensor_state_topic;
-    sensorConfigDoc["unique_id"]             = unique_id + "-" + name;
-    sensorConfigDoc["unit_of_measurement"]   = unit_of_measurement;
-    sensorConfigDoc["device_class"]          = device_class;
-    sensorConfigDoc["payload_available"]     = "online";
-    sensorConfigDoc["payload_not_available"] = "offline";
-    sensorConfigDoc["availability_topic"]    = mqtt_topic + "/status";
+    sensorConfigDoc["name"]                = displayName;
+    sensorConfigDoc["state_topic"]         = sensor_state_topic;
+    sensorConfigDoc["unique_id"]           = unique_id + "-" + name;
+    sensorConfigDoc["unit_of_measurement"] = unit_of_measurement;
+    sensorConfigDoc["device_class"]        = device_class;
+    attachDeviceAndAvailability(sensorConfigDoc, deviceMapDoc, mqtt_topic + "/status");
 
-    auto sensorDeviceField = sensorConfigDoc["device"].to<JsonObject>();
+    sensor_device.payload_json = serializeDiscoveryJson(sensorConfigDoc);
 
-    for (JsonPair keyValue : deviceMapDoc.as<JsonObject>()) {
-        sensorDeviceField[keyValue.key()] = keyValue.value();
-    }
+    return sensor_device;
+}
 
-    String sensorConfigDocBuffer;
-    serializeJson(sensorConfigDoc, sensorConfigDocBuffer);
+MQTTManager::DiscoveryObject MQTTManager::generateBinarySensorDevice(const String& name,
+                                                                     const String& displayName,
+                                                                     const String& device_class,
+                                                                     const String& payload_on,
+                                                                     const String& payload_off) {
+    String          mqtt_topic = String(topicPrefix_) + hostname_;
+    DiscoveryObject sensor_device;
+    String          unique_id                  = "clevercoffee-" + hostname_;
+    String          binarySensorDiscoveryTopic = hassioDiscoveryPrefix_ + "/binary_sensor/";
 
-    sensor_device.payload_json = sensorConfigDocBuffer;
+    String sensor_state_topic     = mqtt_topic + "/" + name;
+    sensor_device.discovery_topic = binarySensorDiscoveryTopic + unique_id + "/" + name + "/config";
+
+    JsonDocument deviceMapDoc;
+    populateDeviceMap(deviceMapDoc, hostname_);
+
+    JsonDocument sensorConfigDoc;
+    sensorConfigDoc["name"]         = displayName;
+    sensorConfigDoc["state_topic"]  = sensor_state_topic;
+    sensorConfigDoc["unique_id"]    = unique_id + "-" + name;
+    sensorConfigDoc["payload_on"]   = payload_on;
+    sensorConfigDoc["payload_off"]  = payload_off;
+    sensorConfigDoc["device_class"] = device_class;
+    attachDeviceAndAvailability(sensorConfigDoc, deviceMapDoc, mqtt_topic + "/status");
+
+    sensor_device.payload_json = serializeDiscoveryJson(sensorConfigDoc);
 
     return sensor_device;
 }
@@ -822,6 +905,10 @@ int MQTTManager::sendHASSIODiscoveryMsg() {
 
     if (Config::getInstance().hardwareSensorsPressureEnabled.get()) {
         failures += publishDiscovery(generateSensorDevice("pressure", "Pressure", "bar", "pressure"));
+    }
+
+    if (Config::getInstance().hardwareSensorsWatertankEnabled.get()) {
+        failures += publishDiscovery(generateBinarySensorDevice("waterTankFull", "Water Tank", "moisture"));
     }
 
     if (failures > 0) {

--- a/src/state/MachineStateContext.cpp
+++ b/src/state/MachineStateContext.cpp
@@ -41,14 +41,6 @@ const TempSensor* MachineStateContext::getTempSensor() const noexcept {
     return hardwareManager_.getTempSensor();
 }
 
-Switch* MachineStateContext::getWaterTankSensor() noexcept {
-    return hardwareManager_.getWaterTankSensor();
-}
-
-const Switch* MachineStateContext::getWaterTankSensor() const noexcept {
-    return hardwareManager_.getWaterTankSensor();
-}
-
 Switch* MachineStateContext::getBrewSwitch() const {
     return hardwareManager_.getBrewSwitch();
 }
@@ -478,12 +470,6 @@ double MachineStateContext::getWeight() const noexcept {
 void MachineStateContext::tareScale() noexcept {
     // Use SensorCoordinator for scale operations
     systemContext_.sensorCoordinator().setScaleTareMode(true);
-}
-
-void MachineStateContext::updateHardware() noexcept {
-    // SensorCoordinator auto-updates in main loop, no manual call needed
-    // Access the coordinator to validate it exists, but no update call is needed
-    (void)(systemContext_.sensorCoordinator());
 }
 
 // === IConfigContext Interface Implementation ===

--- a/src/state/states/ErrorStates.cpp
+++ b/src/state/states/ErrorStates.cpp
@@ -75,6 +75,19 @@ std::optional<MachineStateId> WaterTankEmptyState::checkSpecificTransitions(Mach
     if (context.isWaterTankFull()) {
         return transitionToPidState(context, "Water tank refilled");
     }
+    if (context.isStandbyRequested()) {
+        context.setStandbyRequested(false);
+        context.logStateTransition(getStateId(), MachineStateId::STANDBY, "Standby requested");
+        return MachineStateId::STANDBY;
+    }
+    // Safety: with keep_heater_on_empty the heater may still be running here.
+    // The standby timeout must keep working so the heater never runs unattended
+    // indefinitely while the tank stays empty.
+    context.initializeStandbyTimerIfNeeded();
+    if (context.shouldEnterStandby()) {
+        context.logStateTransition(getStateId(), MachineStateId::STANDBY, "Entering standby mode");
+        return MachineStateId::STANDBY;
+    }
     return std::nullopt;
 }
 

--- a/test/TESTING_GUIDE.md
+++ b/test/TESTING_GUIDE.md
@@ -58,8 +58,7 @@ The following mock implementations are available in `test/mocks/`:
      ```
 
 6. **MockSensorManager** (`MockSensorManager.h`)
-   - Legacy mock for sensor manager
-   - Consider using MockISensor with SensorCoordinator instead
+   - Legacy mock for temperature/pressure only; use `SensorCoordinator` for water tank state
 
 ### Test Helpers
 

--- a/test/mocks/HandlerTestStubs.cpp
+++ b/test/mocks/HandlerTestStubs.cpp
@@ -48,12 +48,18 @@ inline int disablePumpCalls     = 0;
 inline int openWaterValveCalls  = 0;
 inline int enablePumpCalls      = 0;
 inline int closeWaterValveCalls = 0;
+inline int pumpForceOffCalls    = 0;
+inline bool waterTankEmpty      = false;
+inline bool pumpRunning         = false;
 
 inline void reset() noexcept {
-    disablePumpCalls    = 0;
-    openWaterValveCalls = 0;
-    enablePumpCalls     = 0;
+    disablePumpCalls     = 0;
+    openWaterValveCalls  = 0;
+    enablePumpCalls      = 0;
     closeWaterValveCalls = 0;
+    pumpForceOffCalls    = 0;
+    waterTankEmpty       = false;
+    pumpRunning          = false;
 }
 } // namespace TestHardwareSpy
 
@@ -74,20 +80,33 @@ bool HardwareManager::hasTemperatureError() const noexcept { return false; }
 Relay* HardwareManager::getHeaterRelay() noexcept { return nullptr; }
 Relay* HardwareManager::getPumpRelay() noexcept { return nullptr; }
 Relay* HardwareManager::getValveRelay() noexcept { return nullptr; }
-bool HardwareManager::isWaterTankEmpty() const noexcept { return false; }
+bool HardwareManager::isWaterTankEmpty() const noexcept { return TestHardwareSpy::waterTankEmpty; }
 double HardwareManager::getWeight() const noexcept { return 0.0; }
 void HardwareManager::tareScale() noexcept {}
-void HardwareManager::updateHardware() noexcept {}
 void HardwareManager::enableHeater() noexcept {}
 void HardwareManager::disableHeater() noexcept {}
 void HardwareManager::setHeaterPower(uint8_t) noexcept {}
 void HardwareManager::enablePump() noexcept {
+    if (TestHardwareSpy::waterTankEmpty) {
+        return;
+    }
     TestHardwareSpy::enablePumpCalls++;
+    TestHardwareSpy::pumpRunning = true;
 }
 void HardwareManager::disablePump() noexcept {
     TestHardwareSpy::disablePumpCalls++;
+    TestHardwareSpy::pumpRunning = false;
 }
-void HardwareManager::setPumpPressure(float) noexcept {}
+void HardwareManager::setPumpPressure(float bar) noexcept {
+    if (TestHardwareSpy::waterTankEmpty) {
+        return;
+    }
+    if (bar > 0.0f) {
+        enablePump();
+    } else {
+        disablePump();
+    }
+}
 void HardwareManager::updateValveRelay() noexcept {}
 void HardwareManager::openSteamValve() noexcept {}
 void HardwareManager::closeSteamValve() noexcept {}
@@ -102,7 +121,17 @@ void HardwareManager::closeSolenoid() noexcept {}
 void HardwareManager::emergencyShutdown() noexcept {}
 void HardwareManager::safeHardwareShutdown() noexcept {}
 void HardwareManager::clearEmergencyMode() noexcept {}
-void HardwareManager::updateSafetyState() noexcept {}
+void HardwareManager::setWaterTankEmpty(bool empty) noexcept {
+    if (empty == TestHardwareSpy::waterTankEmpty) {
+        return;
+    }
+    TestHardwareSpy::waterTankEmpty = empty;
+    if (empty && TestHardwareSpy::pumpRunning) {
+        TestHardwareSpy::pumpRunning = false;
+        TestHardwareSpy::pumpForceOffCalls++;
+        TestHardwareSpy::disablePumpCalls++;
+    }
+}
 void HardwareManager::cleanupPartialInit() noexcept {}
 Scale* HardwareManager::getScale() noexcept { return nullptr; }
 const Scale* HardwareManager::getScale() const noexcept { return nullptr; }
@@ -150,8 +179,6 @@ MachineStateContext::MachineStateContext(CleverCoffee::SystemContext&   systemCo
 // Hardware Component Access
 TempSensor*       MachineStateContext::getTempSensor() noexcept { return nullptr; }
 const TempSensor* MachineStateContext::getTempSensor() const noexcept { return nullptr; }
-Switch*           MachineStateContext::getWaterTankSensor() noexcept { return nullptr; }
-const Switch*     MachineStateContext::getWaterTankSensor() const noexcept { return nullptr; }
 Switch*           MachineStateContext::getBrewSwitch() const { return nullptr; }
 Switch*           MachineStateContext::getSteamSwitch() const { return nullptr; }
 Switch*           MachineStateContext::getHotWaterSwitch() const { return nullptr; }
@@ -171,7 +198,9 @@ Scale*            MachineStateContext::getScale() const { return nullptr; }
 // Sensor Data Access
 double MachineStateContext::getCurrentTemperature() const noexcept { return 25.0; }
 bool   MachineStateContext::hasTemperatureError() const noexcept { return false; }
-bool   MachineStateContext::isWaterTankFull() const { return true; }
+bool MachineStateContext::isWaterTankFull() const {
+    return systemContext_.sensorCoordinator().isWaterTankFull();
+}
 float  MachineStateContext::getCurrentPressure() const { return 0.0f; }
 float  MachineStateContext::getFilteredPressure() const { return 0.0f; }
 float  MachineStateContext::getCurrentWeight() const noexcept { return 0.0f; }
@@ -312,7 +341,6 @@ void MachineStateContext::updateStateEntryTime(std::chrono::steady_clock::time_p
 bool   MachineStateContext::isWaterTankEmpty() const noexcept { return false; }
 double MachineStateContext::getWeight() const noexcept { return 0.0; }
 void   MachineStateContext::tareScale() noexcept {}
-void   MachineStateContext::updateHardware() noexcept {}
 void   MachineStateContext::enableHeater() noexcept {}
 void   MachineStateContext::disableHeater() noexcept {}
 void   MachineStateContext::setHeaterPower(uint8_t /*percentage*/) noexcept {}

--- a/test/mocks/HandlerTestStubs.cpp
+++ b/test/mocks/HandlerTestStubs.cpp
@@ -51,6 +51,7 @@ inline int closeWaterValveCalls = 0;
 inline int pumpForceOffCalls    = 0;
 inline bool waterTankEmpty      = false;
 inline bool pumpRunning         = false;
+inline bool shouldEnterStandby  = false;
 
 inline void reset() noexcept {
     disablePumpCalls     = 0;
@@ -60,6 +61,7 @@ inline void reset() noexcept {
     pumpForceOffCalls    = 0;
     waterTankEmpty       = false;
     pumpRunning          = false;
+    shouldEnterStandby   = false;
 }
 } // namespace TestHardwareSpy
 
@@ -225,7 +227,7 @@ bool MachineStateContext::isBackflushActive() const { return false; }
 bool MachineStateContext::isPidRuntimeEnabled() const { return systemContext_.isProcessPidEnabled(); }
 bool MachineStateContext::isPidConfigEnabled() const { return Config::getInstance().pidEnabled.get(); }
 bool          MachineStateContext::isEmergencyStop() const { return emergencyStop_; }
-bool          MachineStateContext::shouldEnterStandby() const { return false; }
+bool          MachineStateContext::shouldEnterStandby() const { return CleverCoffee::TestHardwareSpy::shouldEnterStandby; }
 unsigned long MachineStateContext::getStandbyRemainingTime() const { return 0; }
 
 // Timing Functions

--- a/test/mocks/MockHardwareManager.h
+++ b/test/mocks/MockHardwareManager.h
@@ -46,8 +46,6 @@ public:
     MOCK_METHOD(bool, hasTemperatureError, (), (const, noexcept, override));
 
     // Water Tank Sensor
-    MOCK_METHOD(Switch*, getWaterTankSensor, (), (noexcept, override));
-    MOCK_METHOD(const Switch*, getWaterTankSensor, (), (const, noexcept, override));
     MOCK_METHOD(bool, isWaterTankEmpty, (), (const, noexcept, override));
 
     // Relay Control
@@ -62,9 +60,6 @@ public:
     // Scale Operations
     MOCK_METHOD(double, getWeight, (), (const, noexcept, override));
     MOCK_METHOD(void, tareScale, (), (noexcept, override));
-
-    // Hardware Operations
-    MOCK_METHOD(void, updateHardware, (), (noexcept, override));
 
     // High-Level Hardware Control
     MOCK_METHOD(void, enableHeater, (), (noexcept, override));

--- a/test/mocks/MockMachineStateContext.h
+++ b/test/mocks/MockMachineStateContext.h
@@ -49,7 +49,6 @@ class MockMachineStateContext {
 
     // === Hardware Component Access ===
     MOCK_METHOD(TempSensor*, getTemperatureSensor, (), (const));
-    MOCK_METHOD(Switch*, getWaterTankSensor, (), (const));
     MOCK_METHOD(Switch*, getBrewSwitch, (), (const));
     MOCK_METHOD(Switch*, getSteamSwitch, (), (const));
     MOCK_METHOD(Switch*, getHotWaterSwitch, (), (const));

--- a/test/mocks/MockSensorManager.h
+++ b/test/mocks/MockSensorManager.h
@@ -9,7 +9,6 @@ class MockSensorManager {
 private:
     double currentTemperature_        = 20.0;
     float currentPressure_            = 0.0f;
-    bool waterTankFull_               = true;
     bool hasTemperatureError_         = false;
     bool hasScaleError_               = false;
 
@@ -44,15 +43,6 @@ public:
 
     float getFilteredPressure() const {
         return currentPressure_;
-    }
-
-    // Water tank simulation
-    void setWaterTankFull(bool full) {
-        waterTankFull_ = full;
-    }
-
-    bool isWaterTankFull() const {
-        return waterTankFull_;
     }
 
     // Error checks

--- a/test/test_hardware_water_tank/test_main.cpp
+++ b/test/test_hardware_water_tank/test_main.cpp
@@ -1,0 +1,126 @@
+/**
+ * @file test_main.cpp
+ * @brief Unit tests for HardwareManager water tank pump safety guards
+ *
+ * Compiles the production HardwareManager.cpp (plus the real Relay logic) so
+ * the guards under test are the shipped implementation, not a stub. Pump state
+ * is observed at the GPIO level through a spy GPIOPin that records the last
+ * level written to each pin.
+ */
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <memory>
+
+#include "../test_support.h"
+#include "../mocks/ConfigStubs.cpp"
+#include "../../src/Logger.cpp"
+
+#include "clevercoffee/hardware/GPIOPin.h"
+#include "clevercoffee/hardware/pinmapping.h"
+
+// === GPIOPin spy: records the last level written to each pin ===
+namespace TestPins {
+inline std::map<int, bool> level;
+
+inline void reset() {
+    level.clear();
+}
+} // namespace TestPins
+
+GPIOPin::GPIOPin(int pinNumber, Type type) : pin(pinNumber), pinType(type) {}
+void GPIOPin::write(bool value) const noexcept {
+    TestPins::level[pin] = value;
+}
+int GPIOPin::read() const noexcept {
+    return 0;
+}
+GPIOPin::Type GPIOPin::getType() const noexcept {
+    return pinType;
+}
+void GPIOPin::setType(Type newType) {
+    pinType = newType;
+}
+
+// Arduino yield() is not provided by the native test shims
+void yield() {}
+
+// TempSensorDallas stubs — the DallasTemperature native shim is too minimal to
+// compile the real implementation, and these tests never sample temperatures.
+#include "clevercoffee/hardware/tempsensors/TempSensorDallas.h"
+TempSensorDallas::TempSensorDallas(int /*GPIOPin*/) : oneWire_(nullptr), dallasSensor_(nullptr) {}
+TempSensorDallas::~TempSensorDallas() = default;
+bool TempSensorDallas::sample_temperature(double& /*temperature*/) const {
+    return false;
+}
+
+// === Production code under test ===
+#include "../../src/hardware/IOSwitch.cpp"
+#include "../../src/hardware/Relay.cpp"
+#include "../../src/hardware/StandardLED.cpp"
+#include "../../src/hardware/tempsensors/TempSensorTSIC.cpp"
+#include "../../src/hardware/HardwareManager.cpp"
+
+using namespace CleverCoffee;
+
+class HardwareWaterTankTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        g_test_millis = 0;
+        TestPins::reset();
+        // Deterministic relay semantics: HIGH_TRIGGER means on == HIGH
+        (void)Config::getInstance().hardwareRelaysPumpTriggerType.set(::Hardware::RelayTriggerType::HIGH_TRIGGER);
+        hardware_ = std::make_unique<HardwareManager>(Config::getInstance());
+    }
+
+    bool pumpPinOn() const {
+        return TestPins::level[PIN_PUMP];
+    }
+
+    std::unique_ptr<HardwareManager> hardware_;
+};
+
+TEST_F(HardwareWaterTankTest, SetWaterTankEmptyIsNoOpWhenStateUnchanged) {
+    hardware_->setWaterTankEmpty(false);
+
+    EXPECT_FALSE(hardware_->isWaterTankEmpty());
+    EXPECT_FALSE(pumpPinOn());
+}
+
+TEST_F(HardwareWaterTankTest, EnablePumpRefusesWhenTankEmpty) {
+    hardware_->setWaterTankEmpty(true);
+
+    hardware_->enablePump();
+
+    EXPECT_FALSE(pumpPinOn());
+    EXPECT_TRUE(hardware_->isWaterTankEmpty());
+}
+
+TEST_F(HardwareWaterTankTest, SetPumpPressureRefusesWhenTankEmpty) {
+    hardware_->setWaterTankEmpty(true);
+
+    hardware_->setPumpPressure(9.0f);
+
+    EXPECT_FALSE(pumpPinOn());
+}
+
+TEST_F(HardwareWaterTankTest, TransitionToEmptyStopsRunningPump) {
+    hardware_->enablePump();
+    ASSERT_TRUE(pumpPinOn());
+
+    hardware_->setWaterTankEmpty(true);
+
+    EXPECT_FALSE(pumpPinOn());
+    EXPECT_TRUE(hardware_->isWaterTankEmpty());
+}
+
+TEST_F(HardwareWaterTankTest, PumpAllowedAgainAfterRefill) {
+    hardware_->setWaterTankEmpty(true);
+    hardware_->setWaterTankEmpty(false);
+
+    hardware_->enablePump();
+
+    EXPECT_TRUE(pumpPinOn());
+    EXPECT_FALSE(hardware_->isWaterTankEmpty());
+}

--- a/test/test_process_controller/test_main.cpp
+++ b/test/test_process_controller/test_main.cpp
@@ -119,6 +119,7 @@ protected:
         controller_.reset();
         systemContext_.reset();
         emergencyStopState = false;  // Reset for next test
+        Config::getInstance().hardwareSensorsWatertankKeepHeaterOnEmpty.set(false); // Reset for next test
     }
 };
 
@@ -303,6 +304,30 @@ TEST_F(ProcessControllerIntegrationTest, PIDDisabledForDisabledState) {
 
     bool shouldEnable = controller_->shouldPIDBeEnabled(MachineStateId::PID_DISABLED);
     EXPECT_FALSE(shouldEnable) << "PID should be disabled in PID_DISABLED state";
+}
+
+/**
+ * TEST: PID is disabled for water tank empty by default
+ */
+TEST_F(ProcessControllerIntegrationTest, PIDDisabledForWaterTankEmptyByDefault) {
+    controller_->initialize();
+
+    Config::getInstance().hardwareSensorsWatertankKeepHeaterOnEmpty.set(false);
+
+    bool shouldEnable = controller_->shouldPIDBeEnabled(MachineStateId::WATER_TANK_EMPTY);
+    EXPECT_FALSE(shouldEnable) << "PID should be disabled when tank is empty by default";
+}
+
+/**
+ * TEST: PID stays enabled for water tank empty when keep-heater-on-empty is configured
+ */
+TEST_F(ProcessControllerIntegrationTest, PIDStaysEnabledWhenKeepHeaterOnEmptyConfigured) {
+    controller_->initialize();
+
+    Config::getInstance().hardwareSensorsWatertankKeepHeaterOnEmpty.set(true);
+
+    bool shouldEnable = controller_->shouldPIDBeEnabled(MachineStateId::WATER_TANK_EMPTY);
+    EXPECT_TRUE(shouldEnable) << "PID should stay enabled when keep-heater-on-empty is configured";
 }
 
 // ============================================================================

--- a/test/test_sensor_coordinator_water_tank/test_main.cpp
+++ b/test/test_sensor_coordinator_water_tank/test_main.cpp
@@ -1,0 +1,128 @@
+/**
+ * @file test_main.cpp
+ * @brief Unit tests for SensorCoordinator water tank ownership and readings
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "../mocks/ConfigStubs.cpp"
+#include "../mocks/MockSwitch.h"
+#include "../test_support.h"
+#include "clevercoffee/Config.h"
+#include "clevercoffee/context/SystemContext.h"
+#include "clevercoffee/coordinators/SensorCoordinator.h"
+
+#include "../../src/Logger.cpp"
+#include "../../src/coordinators/SensorCoordinator.cpp"
+
+using namespace CleverCoffee;
+using ::testing::Return;
+
+class SensorCoordinatorWaterTankTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        g_test_millis = 0;
+        Config::getInstance().hardwareSensorsWatertankEnabled.set(true);
+    }
+
+    void TearDown() override {
+        Config::getInstance().hardwareSensorsWatertankEnabled.set(false);
+    }
+};
+
+TEST_F(SensorCoordinatorWaterTankTest, OwnsInjectedSensor) {
+    auto        mock = std::make_unique<MockSwitch>(Hardware::SwitchType::TOGGLE, Hardware::SwitchMode::NORMALLY_OPEN);
+    const Switch* raw = mock.get();
+
+    SensorCoordinator coord;
+    coord.setWaterTankSensor(std::move(mock));
+
+    EXPECT_EQ(raw, coord.getWaterTankSensor());
+}
+
+TEST_F(SensorCoordinatorWaterTankTest, DefaultsToFullBeforeFirstRead) {
+    SensorCoordinator coord;
+    EXPECT_TRUE(coord.isWaterTankFull());
+}
+
+TEST_F(SensorCoordinatorWaterTankTest, DetectsTransitionToEmpty) {
+    auto mock     = std::make_unique<MockSwitch>(Hardware::SwitchType::TOGGLE, Hardware::SwitchMode::NORMALLY_OPEN);
+    auto* mockPtr = mock.get();
+    EXPECT_CALL(*mockPtr, isPressed()).WillRepeatedly(Return(false));
+
+    SensorCoordinator coord;
+    coord.setWaterTankSensor(std::move(mock));
+
+    coord.update();
+    g_test_millis = 250;
+    coord.update();
+
+    EXPECT_FALSE(coord.isWaterTankFull());
+}
+
+TEST_F(SensorCoordinatorWaterTankTest, DetectsRefillAfterEmpty) {
+    auto mock     = std::make_unique<MockSwitch>(Hardware::SwitchType::TOGGLE, Hardware::SwitchMode::NORMALLY_OPEN);
+    auto* mockPtr = mock.get();
+
+    SensorCoordinator coord;
+    coord.setWaterTankSensor(std::move(mock));
+
+    EXPECT_CALL(*mockPtr, isPressed()).WillRepeatedly(Return(false));
+    coord.update();
+    g_test_millis = 250;
+    coord.update();
+    ASSERT_FALSE(coord.isWaterTankFull());
+
+    EXPECT_CALL(*mockPtr, isPressed()).WillRepeatedly(Return(true));
+    g_test_millis = 500;
+    coord.update();
+
+    EXPECT_TRUE(coord.isWaterTankFull());
+}
+
+TEST_F(SensorCoordinatorWaterTankTest, IgnoresSensorWhenDisabled) {
+    Config::getInstance().hardwareSensorsWatertankEnabled.set(false);
+
+    auto mock     = std::make_unique<MockSwitch>(Hardware::SwitchType::TOGGLE, Hardware::SwitchMode::NORMALLY_OPEN);
+    auto* mockPtr = mock.get();
+    EXPECT_CALL(*mockPtr, isPressed()).Times(0);
+
+    SensorCoordinator coord;
+    coord.setWaterTankSensor(std::move(mock));
+
+    g_test_millis = 250;
+    coord.update();
+
+    EXPECT_TRUE(coord.isWaterTankFull());
+}
+
+TEST_F(SensorCoordinatorWaterTankTest, ClearingOwnedSensorStopsReads) {
+    auto mock     = std::make_unique<MockSwitch>(Hardware::SwitchType::TOGGLE, Hardware::SwitchMode::NORMALLY_OPEN);
+    auto* mockPtr = mock.get();
+    EXPECT_CALL(*mockPtr, isPressed()).Times(0);
+
+    SensorCoordinator coord;
+    coord.setWaterTankSensor(std::move(mock));
+    coord.setWaterTankSensor(nullptr);
+
+    g_test_millis = 250;
+    coord.update();
+
+    EXPECT_EQ(nullptr, coord.getWaterTankSensor());
+    EXPECT_TRUE(coord.isWaterTankFull());
+}
+
+TEST_F(SensorCoordinatorWaterTankTest, SystemContextUsesSameCoordinatorState) {
+    auto  mock    = std::make_unique<MockSwitch>(Hardware::SwitchType::TOGGLE, Hardware::SwitchMode::NORMALLY_OPEN);
+    auto* mockPtr = mock.get();
+    SystemContext context;
+    context.sensorCoordinator().setWaterTankSensor(std::move(mock));
+
+    EXPECT_CALL(*mockPtr, isPressed()).WillRepeatedly(Return(false));
+    context.sensorCoordinator().update();
+    g_test_millis = 250;
+    context.sensorCoordinator().update();
+
+    EXPECT_FALSE(context.sensorCoordinator().isWaterTankFull());
+}

--- a/test/test_utils/TestHelpers.h
+++ b/test/test_utils/TestHelpers.h
@@ -13,7 +13,6 @@
 #include "../mocks/MockConfig.h"
 #include "../mocks/MockLED.h"
 #include "../mocks/MockRelay.h"
-#include "../mocks/MockSensorManager.h"
 #include "../mocks/MockSwitch.h"
 
 #include "clevercoffee/context/SystemContext.h"
@@ -49,7 +48,6 @@ class TestFixtureBase : public ::testing::Test {
 
     std::unique_ptr<SystemContext> systemContext_;
     MockConfig                    mockConfig_;
-    MockSensorManager             mockSensorManager_;
 };
 
 /**

--- a/test/test_water_tank_empty_state/test_main.cpp
+++ b/test/test_water_tank_empty_state/test_main.cpp
@@ -1,0 +1,167 @@
+/**
+ * @file test_main.cpp
+ * @brief Unit tests for WaterTankEmptyState standby transitions
+ *
+ * Safety requirement: the heater must never run unattended forever. When the
+ * machine sits in WATER_TANK_EMPTY (especially with
+ * hardware.sensors.watertank.keep_heater_on_empty=true), the standby request
+ * and standby timeout must still move the machine to STANDBY, which turns the
+ * heater off. Conversely, a machine already resting in STANDBY must not be
+ * woken up just because the tank is (still) empty.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "../ConfigTestHelper.h"
+#include "../mocks/HandlerTestStubs.cpp"
+#include "../mocks/MockSwitch.h"
+#include "../mocks/MockWiFiManager.h"
+#include "../test_support.h"
+
+#include "clevercoffee/state/MachineStateIds.h"
+#include "clevercoffee/state/states/ErrorStates.h"
+#include "clevercoffee/state/states/SystemStates.h"
+
+const char* getStateName(MachineStateId) {
+    return "test";
+}
+
+#include "../../src/state/states/ErrorStates.cpp"
+#include "../../src/state/states/SystemStates.cpp"
+
+using ::testing::NiceMock;
+using ::testing::Return;
+
+// ============================================================================
+// TEST FIXTURE
+// ============================================================================
+
+class WaterTankEmptyStateTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        g_test_millis = 0;
+        Preferences::resetTestStore();
+        CleverCoffee::TestHardwareSpy::reset();
+        (void)Config::getInstance().hardwareSensorsWatertankEnabled.set(true);
+
+        systemContext_ = std::make_unique<CleverCoffee::SystemContext>();
+        systemContext_->markReady();
+
+        hwManager_      = std::make_unique<CleverCoffee::HardwareManager>(Config::getInstance());
+        displayManager_ = std::make_unique<DisplayManager>(::Hardware::OLEDType::SSD1306,
+                                                           ::Hardware::OLEDAddress::ADDR_3C);
+        mqttManager_    = std::make_unique<MQTTManager>();
+        wifiManager_    = std::make_unique<NiceMock<MockWiFiManager>>();
+
+        context_ = std::make_unique<MachineStateContext>(
+            *systemContext_, *hwManager_, *displayManager_, *wifiManager_, *mqttManager_);
+        systemContext_->setMachineStateContext(context_.get());
+
+        context_->updateStateEntryTime(std::chrono::steady_clock::now());
+    }
+
+    void TearDown() override {
+        systemContext_->setMachineStateContext(nullptr);
+        context_.reset();
+        hwManager_.reset();
+        displayManager_.reset();
+        mqttManager_.reset();
+        wifiManager_.reset();
+        systemContext_.reset();
+        (void)Config::getInstance().hardwareSensorsWatertankEnabled.set(false);
+        g_test_millis = 0;
+    }
+
+    /// Inject a mock tank sensor and drive SensorCoordinator until it reports empty.
+    void makeTankEmpty() {
+        auto mock =
+            std::make_unique<NiceMock<MockSwitch>>(::Hardware::SwitchType::TOGGLE, ::Hardware::SwitchMode::NORMALLY_OPEN);
+        tankSensor_ = mock.get();
+        ON_CALL(*tankSensor_, isPressed()).WillByDefault(Return(false));
+        systemContext_->sensorCoordinator().setWaterTankSensor(std::move(mock));
+
+        systemContext_->sensorCoordinator().update();
+        g_test_millis += 250;
+        systemContext_->sensorCoordinator().update();
+        ASSERT_FALSE(systemContext_->sensorCoordinator().isWaterTankFull());
+    }
+
+    /// Flip the injected sensor back to "water detected" and re-read.
+    void refillTank() {
+        ON_CALL(*tankSensor_, isPressed()).WillByDefault(Return(true));
+        g_test_millis += 250;
+        systemContext_->sensorCoordinator().update();
+        ASSERT_TRUE(systemContext_->sensorCoordinator().isWaterTankFull());
+    }
+
+    std::unique_ptr<CleverCoffee::SystemContext>   systemContext_;
+    std::unique_ptr<CleverCoffee::HardwareManager> hwManager_;
+    std::unique_ptr<DisplayManager>                displayManager_;
+    std::unique_ptr<MQTTManager>                   mqttManager_;
+    std::unique_ptr<NiceMock<MockWiFiManager>>     wifiManager_;
+    std::unique_ptr<MachineStateContext>           context_;
+    NiceMock<MockSwitch>*                          tankSensor_ = nullptr;
+};
+
+// ============================================================================
+// WATER_TANK_EMPTY → STANDBY (heater must not run unattended forever)
+// ============================================================================
+
+TEST_F(WaterTankEmptyStateTest, StandbyRequestTransitionsToStandby) {
+    makeTankEmpty();
+    context_->setStandbyRequested(true);
+
+    WaterTankEmptyState state;
+    auto                next = state.checkTransitions(*context_);
+
+    ASSERT_TRUE(next.has_value()) << "Standby request must be honored while tank is empty";
+    EXPECT_EQ(MachineStateId::STANDBY, next.value());
+    EXPECT_FALSE(context_->isStandbyRequested()) << "Request flag must be drained";
+}
+
+TEST_F(WaterTankEmptyStateTest, StandbyTimeoutTransitionsToStandby) {
+    makeTankEmpty();
+    CleverCoffee::TestHardwareSpy::shouldEnterStandby = true;
+
+    WaterTankEmptyState state;
+    auto                next = state.checkTransitions(*context_);
+
+    ASSERT_TRUE(next.has_value()) << "Standby timeout must fire while tank is empty";
+    EXPECT_EQ(MachineStateId::STANDBY, next.value());
+}
+
+TEST_F(WaterTankEmptyStateTest, StaysPutWithoutStandbySignalOrRefill) {
+    makeTankEmpty();
+
+    WaterTankEmptyState state;
+    auto                next = state.checkTransitions(*context_);
+
+    EXPECT_FALSE(next.has_value()) << "No signal, no transition (self-transitions are noise)";
+}
+
+TEST_F(WaterTankEmptyStateTest, RefillReturnsToPidState) {
+    makeTankEmpty();
+    refillTank();
+
+    WaterTankEmptyState state;
+    auto                next = state.checkTransitions(*context_);
+
+    ASSERT_TRUE(next.has_value());
+    EXPECT_EQ(context_->getPidState(), next.value());
+}
+
+// ============================================================================
+// STANDBY must not be interrupted by an empty tank
+// ============================================================================
+
+TEST_F(WaterTankEmptyStateTest, StandbyStateIsNotForcedOutByEmptyTank) {
+    makeTankEmpty();
+
+    StandbyState standby;
+    auto         next = standby.checkTransitions(*context_);
+
+    EXPECT_FALSE(next.has_value()) << "Standby (heater off) must persist while the tank is empty";
+}

--- a/ui/packages/frontend/src/lib/parameter-groups.ts
+++ b/ui/packages/frontend/src/lib/parameter-groups.ts
@@ -257,6 +257,7 @@ export const parameterGroups: ParameterGroup[] = [
     parameters: [
       "hardware.sensors.watertank.enabled",
       "hardware.sensors.watertank.mode",
+      "hardware.sensors.watertank.keep_heater_on_empty",
     ],
   },
   {

--- a/ui/packages/frontend/src/lib/parameter-help-texts.ts
+++ b/ui/packages/frontend/src/lib/parameter-help-texts.ts
@@ -148,6 +148,8 @@ export const parameterHelpTexts: Record<string, string> = {
   "hardware.sensors.watertank.enabled": "Enable water tank level sensor",
   "hardware.sensors.watertank.mode":
     "Electrical configuration of water tank sensor",
+  "hardware.sensors.watertank.keep_heater_on_empty":
+    "Warning: keeps the PID/heater active even when the water tank is reported empty. Only the external reservoir is protected by this sensor, not the boiler.",
   "hardware.sensors.scale.enabled":
     "Enable integrated scale for weight-based brewing",
   "hardware.sensors.scale.type": "Scale load cell configuration",

--- a/ui/packages/frontend/src/lib/parameter-labels.ts
+++ b/ui/packages/frontend/src/lib/parameter-labels.ts
@@ -134,6 +134,10 @@ export const parameterLabelsEN = new Map<string, string>([
   ["hardware.sensors.pressure.enabled", "Enable Pressure Sensor"],
   ["hardware.sensors.watertank.enabled", "Enable Water Tank Sensor"],
   ["hardware.sensors.watertank.mode", "Water Tank Sensor Mode"],
+  [
+    "hardware.sensors.watertank.keep_heater_on_empty",
+    "Keep Heater On When Tank Empty",
+  ],
   ["hardware.sensors.scale.enabled", "Enable Scale"],
   ["hardware.sensors.scale.type", "Scale Setup Type"],
   ["hardware.sensors.scale.samples", "Scale Samples"],

--- a/ui/packages/frontend/src/lib/parameter-metadata.ts
+++ b/ui/packages/frontend/src/lib/parameter-metadata.ts
@@ -741,6 +741,14 @@ export const defaultParametersList: Array<ParameterTemplate> = [
     ],
     requiredParameters: { "hardware.sensors.watertank.enabled": true },
   },
+  {
+    name: "hardware.sensors.watertank.keep_heater_on_empty",
+    type: ParameterTypes.BOOL,
+    min: 0,
+    max: 1,
+    defaultValue: false,
+    requiredParameters: { "hardware.sensors.watertank.enabled": true },
+  },
 
   // Display Parameters
   {

--- a/ui/packages/mock-server/data/parameters.json
+++ b/ui/packages/mock-server/data/parameters.json
@@ -672,6 +672,18 @@
     ]
   },
   {
+    "name": "hardware.sensors.watertank.keep_heater_on_empty",
+    "displayName": "Keep Heater On When Tank Empty",
+    "section": 4,
+    "position": 2423,
+    "hasHelpText": true,
+    "show": true,
+    "type": 6,
+    "value": false,
+    "min": 0,
+    "max": 1
+  },
+  {
     "name": "hardware.switches.brew.enabled",
     "displayName": "Enable Brew Switch",
     "section": 13,


### PR DESCRIPTION
## Summary

This PR adds an **opt-in config flag** to keep the boiler PID/heater running while the external water tank is reported empty, exports tank state over **MQTT and Home Assistant**, and fixes a **latent pump-safety bug** where `HardwareManager` tank guards were never wired to live sensor data. It also refactors water tank handling so `SensorCoordinator` is the single source of truth end-to-end.

**Default behavior is unchanged** (`keep_heater_on_empty=false`): tank empty still disables the heater and blocks the pump.

**Safety net:** even with the flag enabled, the standby timeout still applies inside `WATER_TANK_EMPTY` — the heater never runs unattended indefinitely.

---

## New feature: keep heater on when tank is empty

### Config

| Key | Type | Default | Reboot required |
|-----|------|---------|-----------------|
| `hardware.sensors.watertank.keep_heater_on_empty` | bool | `false` | No |

Documented in `CONFIG_REFERENCE.md`. Surfaced in the web UI under **Water Tank Sensors** (visible when `hardware.sensors.watertank.enabled=true`).

### Runtime behavior

When the tank sensor reports empty, the machine **still enters `WATER_TANK_EMPTY`** (brew, hot water, and backflush remain blocked via existing handler/state checks). Only the **heater/PID keep-alive** changes:

| `keep_heater_on_empty` | Heater/PID in `WATER_TANK_EMPTY` | Pump |
|------------------------|----------------------------------|------|
| `false` (default) | Off | Blocked |
| `true` | Stays on (tracks setpoint) | Still blocked |

Implementation: `ProcessController::shouldPIDBeEnabled()` only treats `WATER_TANK_EMPTY` as a PID-disable condition when the flag is off.

**Standby interaction (safety):**

- A standby request (power switch/MQTT) is honored while in `WATER_TANK_EMPTY`.
- The **standby timeout still fires** in `WATER_TANK_EMPTY`: if the tank stays empty past the configured standby time, the machine enters `STANDBY` and the heater turns off. With `keep_heater_on_empty=true` this bounds unattended heating.
- An empty tank does **not** wake a machine already in `STANDBY` (previously, removing the tank forced `STANDBY` → `WATER_TANK_EMPTY`, which with the flag set would have fired the heater up on a resting machine).

This required fixing a transition-ordering issue: `BaseState::checkTransitions` returned a `WATER_TANK_EMPTY` self-transition before the state's own transition checks could run, so `WATER_TANK_EMPTY` and `STANDBY` are now excluded from the tank-empty force-transition.

**Important:** The water tank sensor protects the **external reservoir**, not the boiler itself. The UI and config help text warn about this explicitly.

---

## New feature: MQTT & Home Assistant tank export

When `hardware.sensors.watertank.enabled=true`:

- **MQTT topic:** `<prefix>/<hostname>/waterTankFull`
- **Payloads:** `ON` (full) / `OFF` (empty) via new `registerBinarySensor()`, published **retained** — a restarted broker or Home Assistant instance immediately receives the current state instead of showing *unknown* until the next transition
- **Home Assistant:** Auto-discovery as a `binary_sensor` with `device_class: moisture` (wet/dry)

The web API parameter `state.water_tank` now reads from `SensorCoordinator` (same source as MQTT).

---

## Bug fix: pump safety guard was dead in production

`HardwareManager::updateHardware()` → `updateSafetyState()` was intended to poll the tank sensor and gate `enablePump()` / `setPumpPressure()`. **`updateHardware()` had zero callers**, so `waterTankEmpty_` stayed at its default and pump-level guards never engaged.

**Fix:** `LoopManager` pushes live tank state into `HardwareManager::setWaterTankEmpty()` after each sensor read. On transition to empty, a running pump is force-stopped immediately.

---

## Refactoring & architecture cleanup

### Single source of truth: `SensorCoordinator`

All tank state now flows from one place:

```
GPIO (IOSwitch) → SensorCoordinator::isWaterTankFull()
                        ├→ State machine (WATER_TANK_EMPTY transitions)
                        ├→ HardwareManager::setWaterTankEmpty() (pump guards)
                        ├→ ProcessController (via state + keep-heater flag)
                        ├→ MQTT / HA / state.water_tank API
                        └→ Web UI
```

Changes included:

- **Sensor ownership moved** from `HardwareManager` to `SensorCoordinator` (`std::unique_ptr<Switch>`). `SystemInitializer` creates the `IOSwitch` and transfers ownership.
- **Removed dead code:** `updateHardware()` from `IHardwareContext`, redundant `waterTankTimer_`, unused debounce members, stale `MachineStateContext::waterTankFull_`, unused `HardwareContext::waterTankSensor_` pointer.
- **`LED::setGPIOState` is now pure virtual** — it was declared but defined nowhere, leaving `LED` without an emitted vtable off-device.
- **MQTT publish cursors** in `writeSysParamsToMQTT()` moved from function-local statics to member state (per-instance instead of bound to whichever instance called first).
- **Main loop reordered** so tank-empty is handled in the **same iteration**:
  1. Sensors + `setWaterTankEmpty`
  2. Switches / standby
  3. State machine
  4. Process control + LEDs
  5. Network / website / display

Previously, process control ran before sensor reads, causing up to one loop of lag on pump guards and PID response.

---

## Files changed (high level)

| Area | What changed |
|------|--------------|
| `ProcessController` | PID gating respects `keep_heater_on_empty` |
| `BaseState` / `ErrorStates` | `WATER_TANK_EMPTY` honors standby request/timeout; `STANDBY` not forced out by empty tank |
| `LoopManager` | Sensor-first loop order; push tank state to HM |
| `SensorCoordinator` | Owns tank sensor; single `isWaterTankFull()` |
| `HardwareManager` | `setWaterTankEmpty()` push model; no sensor ownership |
| `MQTTManager` | `registerBinarySensor()` (retained), shared HA discovery helpers, member publish cursors |
| `SystemInitializer` | Creates tank sensor; registers MQTT binary sensor |
| `Config` / UI | New parameter + labels, help text, mock server entry |
| Tests | +16 new native tests across 4 suites |
| Docs | `CONFIG_REFERENCE`, integration-tests §10, state-machine architecture |

---

## Test coverage

**336 native tests pass** (16 new):

| Suite | Tests |
|-------|-------|
| `test_process_controller` | PID off by default when tank empty; PID stays on when flag set |
| `test_hardware_water_tank` | Pump refuse, force-off on empty transition, refill re-enable — compiles the **production** `HardwareManager.cpp` with a GPIO spy (mutation-verified: removing the guard fails the suite) |
| `test_sensor_coordinator_water_tank` | Ownership, empty/refill transitions, disabled sensor, SystemContext wiring |
| `test_water_tank_empty_state` | Standby request/timeout from `WATER_TANK_EMPTY`, refill recovery, `STANDBY` not woken by empty tank |

---

## Manual verification

See **`docs/integration-tests.md` §10** for the hardware checklist:

- Pump blocked / force-stopped when tank goes empty
- Heater off (default) vs on (flag enabled) in `WATER_TANK_EMPTY`
- Standby timeout enters `STANDBY` (heater off) while tank stays empty; standby request honored; tank removal doesn't wake a machine in standby
- MQTT `ON`/`OFF` on `waterTankFull` topic, retained for fresh subscribers
- HA `binary_sensor` discovery

---

## Breaking / migration notes

- **MQTT:** `waterTankFull` now publishes `ON`/`OFF` strings (was briefly `1.00`/`0.00` as a numeric sensor in an earlier commit) and is **retained**. Update any external automations accordingly; if you later disable the feature, clear the retained message with `mosquitto_pub -r -n -t '<prefix>/<hostname>/waterTankFull'`.
- **No config migration needed** — new flag defaults to `false`.
- **No reboot** required to toggle `keep_heater_on_empty`; read live every control loop.
