### PR TITLE
fix(mqtt): stop classifying water tank as moisture sensor in HA

### DIFF
--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -99,8 +99,9 @@ A single out-of-range TSIC sample must never trip emergency stop or flood the lo
 - [ ] Removing the tank while the machine is in `Standby` does NOT wake it up
       (it stays in standby with the heater off)
 - [ ] With a Home Assistant instance subscribed to the MQTT discovery prefix, a
-      "Water Tank" binary_sensor entity appears (wet when full, dry when empty)
-      after connecting with `hardware.sensors.watertank.enabled=true`
+      "Water Tank Full" binary_sensor entity appears (on when full, off when empty;
+      not classified as a moisture/leak sensor) after connecting with
+      `hardware.sensors.watertank.enabled=true`
 - [ ] `mosquitto_sub -t '<prefix>/<hostname>/waterTankFull'` reports `ON` when full
       and `OFF` when empty; the message is retained, so a fresh subscriber (or a
       restarted Home Assistant) receives the current state immediately

--- a/include/clevercoffee/network/MQTTManager.h
+++ b/include/clevercoffee/network/MQTTManager.h
@@ -327,9 +327,9 @@ class MQTTManager : public IMQTTManager {
                                          const String& device_class);
     DiscoveryObject generateBinarySensorDevice(const String& name,
                                                const String& displayName,
-                                               const String& device_class,
-                                               const String& payload_on  = "ON",
-                                               const String& payload_off = "OFF");
+                                               const String& device_class = "",
+                                               const String& payload_on   = "ON",
+                                               const String& payload_off  = "OFF");
     DiscoveryObject generateNumberDevice(const String& name,
                                          const String& displayName,
                                          int           min_value,

--- a/src/network/MQTTManager.cpp
+++ b/src/network/MQTTManager.cpp
@@ -744,12 +744,14 @@ MQTTManager::DiscoveryObject MQTTManager::generateBinarySensorDevice(const Strin
     populateDeviceMap(deviceMapDoc, hostname_);
 
     JsonDocument sensorConfigDoc;
-    sensorConfigDoc["name"]         = displayName;
-    sensorConfigDoc["state_topic"]  = sensor_state_topic;
-    sensorConfigDoc["unique_id"]    = unique_id + "-" + name;
-    sensorConfigDoc["payload_on"]   = payload_on;
-    sensorConfigDoc["payload_off"]  = payload_off;
-    sensorConfigDoc["device_class"] = device_class;
+    sensorConfigDoc["name"]        = displayName;
+    sensorConfigDoc["state_topic"] = sensor_state_topic;
+    sensorConfigDoc["unique_id"]   = unique_id + "-" + name;
+    sensorConfigDoc["payload_on"]  = payload_on;
+    sensorConfigDoc["payload_off"] = payload_off;
+    if (!device_class.isEmpty()) {
+        sensorConfigDoc["device_class"] = device_class;
+    }
     attachDeviceAndAvailability(sensorConfigDoc, deviceMapDoc, mqtt_topic + "/status");
 
     sensor_device.payload_json = serializeDiscoveryJson(sensorConfigDoc);
@@ -908,7 +910,7 @@ int MQTTManager::sendHASSIODiscoveryMsg() {
     }
 
     if (Config::getInstance().hardwareSensorsWatertankEnabled.get()) {
-        failures += publishDiscovery(generateBinarySensorDevice("waterTankFull", "Water Tank", "moisture"));
+        failures += publishDiscovery(generateBinarySensorDevice("waterTankFull", "Water Tank Full"));
     }
 
     if (failures > 0) {


### PR DESCRIPTION
## Summary

- Remove `device_class: moisture` from the water tank Home Assistant MQTT discovery payload — that class is for leak/wetness detectors and made HA show **Wet/Dry** instead of tank level
- Rename the entity to **Water Tank Full** so generic **On/Off** states read as full/empty
- Omit `device_class` from discovery JSON when not set (cleaner payload)

MQTT topic and payloads are unchanged (`waterTankFull` → `ON`/`OFF` retained).

## Test plan

- [x] `pio run --target format -e esp32_usb -s`
- [x] `pio run -e esp32_usb -s`
- [x] `pio test -e native_test`
- [ ] With HA discovery enabled and watertank sensor on, entity shows as **Water Tank Full** with On/Off (not Wet/Dry)
- [ ] `mosquitto_sub -t '<prefix>/<hostname>/waterTankFull'` still reports `ON`/`OFF`