### PR TITLE
fix(wifi): set STA hostname before WiFi.begin

### DIFF
--- a/include/clevercoffee/network/WiFiStaConnect.h
+++ b/include/clevercoffee/network/WiFiStaConnect.h
@@ -1,0 +1,41 @@
+/**
+ * @file WiFiStaConnect.h
+ * @brief Apply STA hostname before WiFi.begin so DHCP client ID matches config
+ */
+
+#pragma once
+
+#include <Arduino.h>
+#include <WiFi.h>
+
+namespace CleverCoffee::Network {
+
+inline void applyStaHostname(const String& hostname) {
+    if (hostname.isEmpty()) {
+        return;
+    }
+    WiFi.setHostname(hostname.c_str());
+}
+
+/**
+ * @brief Set DHCP/STA hostname then start connection to an explicit SSID
+ */
+inline void beginStaWithHostname(const String& hostname, const String& ssid, const String& password) {
+    applyStaHostname(hostname);
+    if (password.isEmpty()) {
+        WiFi.begin(ssid.c_str());
+    } else {
+        WiFi.begin(ssid.c_str(), password.c_str());
+    }
+}
+
+/**
+ * @brief Reconnect using saved credentials, re-applying hostname first
+ */
+inline void reconnectStaWithHostname(const String& hostname) {
+    WiFi.disconnect();
+    applyStaHostname(hostname);
+    WiFi.begin();
+}
+
+} // namespace CleverCoffee::Network

--- a/src/network/CleverCoffeeWiFiManager.cpp
+++ b/src/network/CleverCoffeeWiFiManager.cpp
@@ -11,6 +11,7 @@
 #include "clevercoffee/coordinators/NetworkCoordinator.h"
 #include "clevercoffee/display/languages.h"
 #include "clevercoffee/handlers/BrewHandler.h"
+#include "clevercoffee/network/WiFiStaConnect.h"
 #include "clevercoffee/types/GlobalTypes.h"
 #include "clevercoffee/utils/Resilience.h"
 
@@ -90,11 +91,7 @@ bool CleverCoffeeWiFiManager::attemptConnection(const String&                   
     const String wifiPassword = Config::getInstance().systemWifiPassword.get();
     if (!wifiSsid.isEmpty()) {
         LOGF(INFO, "Connecting to WiFi from config: %s", wifiSsid.c_str());
-        if (wifiPassword.isEmpty()) {
-            WiFi.begin(wifiSsid.c_str());
-        } else {
-            WiFi.begin(wifiSsid.c_str(), wifiPassword.c_str());
-        }
+        CleverCoffee::Network::beginStaWithHostname(hostname, wifiSsid, wifiPassword);
 
         const unsigned long start = millis();
         while (WiFi.status() != WL_CONNECTED && (millis() - start) < 10000) {
@@ -287,8 +284,7 @@ void CleverCoffeeWiFiManager::checkAndMaintainConnection() {
          retryPolicy_->getCurrentAttempt(),
          retryPolicy_->getNextDelay());
 
-    WiFi.disconnect();
-    WiFi.begin();
+    CleverCoffee::Network::reconnectStaWithHostname(Config::getInstance().systemHostname.get());
 
     // Use yield() instead of delay() to avoid blocking other tasks
     yield();

--- a/test/Arduino.h
+++ b/test/Arduino.h
@@ -358,10 +358,69 @@ public:
         WL_DISCONNECTED = 6,
         WL_CONNECT_FAILED = 4
     } wl_status_t;
-    
-    wl_status_t status() { return WL_DISCONNECTED; }
-    String SSID() { return ""; }
+
+    void resetTestState() {
+        hostname_ = "";
+        lastSsid_ = "";
+        lastPassword_ = "";
+        beginCallCount_ = 0;
+        setHostnameCallCount_ = 0;
+        hostnameSetBeforeBegin_ = false;
+        status_ = WL_DISCONNECTED;
+    }
+
+    bool setHostname(const char* hostname) {
+        ++setHostnameCallCount_;
+        hostname_ = hostname ? hostname : "";
+        if (beginCallCount_ == 0 && hostname_.length() > 0) {
+            hostnameSetBeforeBegin_ = true;
+        }
+        return true;
+    }
+
+    wl_status_t begin(const char* ssid) {
+        ++beginCallCount_;
+        lastSsid_ = ssid ? ssid : "";
+        lastPassword_ = "";
+        status_ = WL_CONNECTED;
+        return status_;
+    }
+
+    wl_status_t begin(const char* ssid, const char* password) {
+        ++beginCallCount_;
+        lastSsid_ = ssid ? ssid : "";
+        lastPassword_ = password ? password : "";
+        status_ = WL_CONNECTED;
+        return status_;
+    }
+
+    wl_status_t begin() {
+        ++beginCallCount_;
+        status_ = WL_CONNECTED;
+        return status_;
+    }
+
+    void disconnect() { status_ = WL_DISCONNECTED; }
+
+    wl_status_t status() { return status_; }
+    String SSID() { return lastSsid_; }
     IPAddress localIP() { return IPAddress(0,0,0,0); }
+
+    const String& testHostname() const { return hostname_; }
+    const String& testLastSsid() const { return lastSsid_; }
+    const String& testLastPassword() const { return lastPassword_; }
+    int testBeginCallCount() const { return beginCallCount_; }
+    int testSetHostnameCallCount() const { return setHostnameCallCount_; }
+    bool testHostnameSetBeforeBegin() const { return hostnameSetBeforeBegin_; }
+
+private:
+    String hostname_;
+    String lastSsid_;
+    String lastPassword_;
+    int beginCallCount_ = 0;
+    int setHostnameCallCount_ = 0;
+    bool hostnameSetBeforeBegin_ = false;
+    wl_status_t status_ = WL_DISCONNECTED;
 };
 inline WiFiClass WiFi;
 

--- a/test/test_wifi_sta_hostname/test_main.cpp
+++ b/test/test_wifi_sta_hostname/test_main.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file test_main.cpp
+ * @brief Hostname must be applied before STA begin for DHCP client ID
+ */
+
+#include "../test_support.h"
+#include "network/WiFiStaConnect.h"
+
+#include <WiFi.h>
+#include <gtest/gtest.h>
+
+class WiFiStaHostnameTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        WiFi.resetTestState();
+    }
+};
+
+TEST_F(WiFiStaHostnameTest, BeginWithPasswordSetsHostnameBeforeBegin) {
+    CleverCoffee::Network::beginStaWithHostname("my-silvia", "HomeNet", "secret");
+
+    EXPECT_EQ(WiFi.testSetHostnameCallCount(), 1);
+    EXPECT_EQ(WiFi.testHostname(), String("my-silvia"));
+    EXPECT_TRUE(WiFi.testHostnameSetBeforeBegin());
+    EXPECT_EQ(WiFi.testBeginCallCount(), 1);
+    EXPECT_EQ(WiFi.testLastSsid(), String("HomeNet"));
+    EXPECT_EQ(WiFi.testLastPassword(), String("secret"));
+}
+
+TEST_F(WiFiStaHostnameTest, BeginOpenNetworkSetsHostnameBeforeBegin) {
+    CleverCoffee::Network::beginStaWithHostname("open-box", "OpenSSID", "");
+
+    EXPECT_TRUE(WiFi.testHostnameSetBeforeBegin());
+    EXPECT_EQ(WiFi.testHostname(), String("open-box"));
+    EXPECT_EQ(WiFi.testLastSsid(), String("OpenSSID"));
+    EXPECT_TRUE(WiFi.testLastPassword().isEmpty());
+}
+
+TEST_F(WiFiStaHostnameTest, ReconnectAppliesHostnameBeforeBegin) {
+    CleverCoffee::Network::reconnectStaWithHostname("rejoin-host");
+
+    EXPECT_EQ(WiFi.testSetHostnameCallCount(), 1);
+    EXPECT_EQ(WiFi.testHostname(), String("rejoin-host"));
+    EXPECT_TRUE(WiFi.testHostnameSetBeforeBegin());
+    EXPECT_EQ(WiFi.testBeginCallCount(), 1);
+    EXPECT_EQ(WiFi.status(), WiFiClass::WL_CONNECTED);
+}
+
+TEST_F(WiFiStaHostnameTest, EmptyHostnameStillBegins) {
+    CleverCoffee::Network::beginStaWithHostname("", "Net", "pw");
+
+    EXPECT_EQ(WiFi.testSetHostnameCallCount(), 0);
+    EXPECT_EQ(WiFi.testBeginCallCount(), 1);
+    EXPECT_EQ(WiFi.testLastSsid(), String("Net"));
+}


### PR DESCRIPTION
## Summary
- Config-SSID WiFi path called `WiFi.begin` without `WiFi.setHostname`, so DHCP kept the default/old name after UI or `/config.json` hostname changes
- Reconnect path had the same gap
- Add `WiFiStaConnect` helper + native tests that assert hostname is applied before begin

## Test plan
- [x] `pio run -e esp32_usb`
- [x] `pio test -e native_test` (340 passed, incl. `test_wifi_sta_hostname`)
- [ ] Flash device with `system.wifi.ssid` + custom `system.hostname`, reboot, confirm router DHCP client name matches
- [ ] Change hostname via UI, reboot, confirm DHCP updates