### PR TITLE
fix(ota): repair firmware updates on all three paths

### DIFF
--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -16,8 +16,49 @@ Pre-release validation. Every item must pass before merging to main or tagging a
 
 ## 2. OTA Update
 
+All three update paths must be exercised — they use independent code paths and
+have each broken separately before.
+
+### 2a. ArduinoOTA / espota (`pio`)
+
 - [ ] `pio run -e esp32_ota -t upload` completes at 100% with "Result: OK"
 - [ ] Device reboots and responds to `/api/health` within 15s after OTA
+- [ ] Serial log shows **no** `task_wdt: Task watchdog got triggered` during the
+      transfer. The transfer blocks `loop()` for ~25s, so the Task Watchdog must
+      be suspended for its whole duration (regression: espota died at ~18% with
+      `OTA_RECEIVE_ERROR` because the watchdog rebooted the device mid-flash).
+
+### 2b. HTTP firmware upload (`/api/ota/firmware`, used by the web UI)
+
+```sh
+curl -w "\n%{http_code}\n" -X POST http://<ip>/api/ota/firmware \
+  -F "firmware=@.pio/build/esp32_usb/firmware.bin;filename=firmware.bin"
+```
+
+- [ ] Responds **200** with `{"success": true, ...}` (regression: returned 400
+      "No firmware file provided" because the request callback overwrote the
+      upload callback's response — the request callback runs *after* the body)
+- [ ] Device reboots on its own within ~20s (regression: the scheduled restart
+      never fired because it was only polled while an OTA was active)
+- [ ] Rejections return the correct status and leave `/api/ota/status` at
+      `idle`, not `error`:
+  - [ ] no file at all → 400 "No firmware file provided"
+  - [ ] `filename=bad.txt` → 400 "Invalid firmware file. Expected .bin extension."
+  - [ ] `/api/ota/filesystem` with `bad.txt` → 400 "Invalid filesystem file..."
+
+### 2c. URL-based update (`/api/ota/url`)
+
+```sh
+(cd .pio/build/esp32_usb && python3 -m http.server 8765 &)
+curl -w "\n%{http_code}\n" -X POST http://<ip>/api/ota/url \
+  -d "url=http://<host-ip>:8765/firmware.bin&type=firmware"
+```
+
+- [ ] Responds **202** immediately, before the download finishes (regression:
+      the download ran inside the async web handler, starving AsyncTCP so the
+      client got no response at all / broken pipe)
+- [ ] `/api/ota/status` reports rising `progress` with `status: "downloading"`
+- [ ] Device reboots and comes back; status returns to `idle`
 
 ## 3. USB Serial Logging
 

--- a/include/clevercoffee/ota.h
+++ b/include/clevercoffee/ota.h
@@ -21,6 +21,7 @@ namespace OTA {
 
 namespace Status {
 constexpr const char* Idle        = "idle";
+constexpr const char* Queued      = "queued";
 constexpr const char* Uploading   = "uploading";
 constexpr const char* Downloading = "downloading";
 constexpr const char* Processing  = "processing";
@@ -177,6 +178,7 @@ void handleFilesystemUpload(
     AsyncWebServerRequest* request, const String& filename, size_t index, uint8_t* data, size_t len, bool final);
 
 void handleURLUpdate(AsyncWebServerRequest* request);
+void pollPendingUrlUpdate() noexcept;
 void handleStatus(AsyncWebServerRequest* request);
 
 [[nodiscard]] uint8_t       getProgress();

--- a/include/clevercoffee/utils/Resilience.h
+++ b/include/clevercoffee/utils/Resilience.h
@@ -435,11 +435,11 @@ class Watchdog {
             return;
         }
 
-        // Subscribe current task to watchdog
-        ret = esp_task_wdt_add(nullptr);
-        if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
-            LOGF(WARNING, "Failed to subscribe task to watchdog: %d", ret);
-        }
+        // Subscribe the Arduino loop task through the core's own helper so that
+        // loopTaskWDTEnabled stays in sync with the TWDT subscription. Using
+        // esp_task_wdt_add() directly desynchronises the core's bookkeeping and
+        // makes suspend() unable to disarm the watchdog (blocking OTA -> panic).
+        enableLoopWDT();
 
         lastFeedTime_ = millis();
 #else
@@ -523,13 +523,18 @@ class Watchdog {
     /**
      * @brief Unsubscribe loop task from TWDT during long blocking operations
      *        (e.g. OTA flash writes, WiFi connect / config portal)
+     *
+     * Idempotent: the loop task is always unsubscribed on return, so a stale
+     * suspended_ flag can never leave the watchdog armed during a blocking
+     * operation.
      */
     void suspend() {
 #if defined(ESP32)
-        if (!enabled_ || suspended_) {
+        if (!enabled_) {
             return;
         }
-        if (esp_task_wdt_delete(nullptr) == ESP_OK) {
+        disableLoopWDT();
+        if (!suspended_) {
             suspended_ = true;
             LOG(INFO, "Watchdog suspended for blocking operation");
         }
@@ -538,18 +543,20 @@ class Watchdog {
 
     /**
      * @brief Re-subscribe loop task to TWDT after the blocking operation completes or fails
+     *
+     * No-op unless suspended, so it cannot re-arm the watchdog on behalf of
+     * another owner (CleverCoffeeWiFiManager toggles the loop WDT directly too).
      */
     void resume() {
 #if defined(ESP32)
         if (!enabled_ || !suspended_) {
             return;
         }
-        if (esp_task_wdt_add(nullptr) == ESP_OK) {
-            esp_task_wdt_reset();
-            suspended_    = false;
-            lastFeedTime_ = millis();
-            LOG(INFO, "Watchdog resumed after blocking operation");
-        }
+        enableLoopWDT();
+        esp_task_wdt_reset();
+        lastFeedTime_ = millis();
+        suspended_    = false;
+        LOG(INFO, "Watchdog resumed after blocking operation");
 #endif
     }
 

--- a/src/core/LoopManager.cpp
+++ b/src/core/LoopManager.cpp
@@ -118,6 +118,13 @@ void LoopManager::update() {
         loggerTime = millis() - stepStart;
     }
 
+    // Must run before the isActive() early-return below: a queued URL update
+    // reports as "in progress" but has not started flashing yet, so it would
+    // never get serviced from inside that branch. Likewise a restart scheduled
+    // by a finished OTA must still fire once the session is no longer active.
+    OTA::pollPendingRestart();
+    OTA::pollPendingUrlUpdate();
+
     if (OTA::isActive()) {
         OTA::runMainLoopTick();
         Logger::update();

--- a/src/core/SystemInitializer.cpp
+++ b/src/core/SystemInitializer.cpp
@@ -810,8 +810,9 @@ CleverCoffeeWiFiManager& SystemInitializer::getWiFiManager() const {
 }
 
 void SystemInitializer::setupWiFi() {
-    // startConfigPortal blocks loopTask for up to 60s; suspend our TWDT subscription (disableLoopWDT
-    // only removes the Arduino framework subscription, not esp_task_wdt_add from Watchdog::begin).
+    // startConfigPortal blocks loopTask for up to 60s, so the Task Watchdog must be
+    // suspended for its duration. Watchdog::suspend() goes through the Arduino core's
+    // disableLoopWDT(), which is the same bookkeeping CleverCoffeeWiFiManager uses.
     struct WatchdogResumeGuard {
         Watchdog* wdt;
         explicit WatchdogResumeGuard(Watchdog* watchdog) : wdt(watchdog) {

--- a/src/ota.cpp
+++ b/src/ota.cpp
@@ -26,6 +26,8 @@ inline auto& getOTAState() noexcept {
 constexpr unsigned long OTA_ERROR_DISPLAY_MS    = 30000;
 constexpr unsigned long OTA_COMPLETE_DISPLAY_MS = 5000;
 constexpr unsigned long OTA_RESTART_DELAY_MS    = 1000;
+/// Lets AsyncTCP flush the /api/ota/url response before the blocking download.
+constexpr unsigned long URL_UPDATE_START_DELAY_MS = 500;
 
 static const char* FILESYSTEM_PARTITION_LABEL = "spiffs";
 
@@ -36,6 +38,50 @@ bool                         g_restartPending    = false;
 unsigned long                g_restartAtMs       = 0;
 uint8_t                      g_lastLoggedDecile  = 255;
 uint8_t                      g_lastDisplayDecile = 255;
+
+String        g_pendingUrl{};
+bool          g_pendingUrlIsFilesystem = false;
+bool          g_pendingUrlQueued       = false;
+unsigned long g_pendingUrlStartAtMs    = 0;
+
+/// Set when an upload is rejected up-front (bad extension, already updating,
+/// Update.begin() failure) or aborted mid-stream. Remaining chunks of that
+/// request must be ignored so the recorded result is not overwritten by the
+/// finalize path.
+bool g_uploadRejected = false;
+
+/// Response the upload callback wants returned. The request callback only runs
+/// after the whole body is parsed, so the upload callback cannot answer the
+/// request itself (its response would be replaced). Kept out of OTAStateManager
+/// because beginSession() resets that state, which would discard a rejection
+/// recorded for a concurrent request. Code 0 means "no upload data arrived".
+int    g_uploadHttpCode = 0;
+String g_uploadHttpBody{};
+
+void setUploadResult(int code, const String& body) {
+    g_uploadHttpCode = code;
+    g_uploadHttpBody = body;
+}
+
+void clearUploadResult() {
+    g_uploadHttpCode = 0;
+    g_uploadHttpBody = String();
+}
+
+/// True while any update is running or a URL update is queued but not yet
+/// started. A queued URL update has not touched Update yet, so
+/// isUpdateInProgress() alone would let a concurrent upload start a second
+/// flash during the start delay.
+bool otaBusy() {
+    return isUpdateInProgress() || g_pendingUrlQueued;
+}
+
+/// True only while flash is actually being written. Unlike isActive() /
+/// isUpdateInProgress(), this does not match the "queued" status, so a queued
+/// URL update does not see itself as a competing update.
+bool flashInProgress() {
+    return Update.isRunning() || getOTAState().isUpdateStarted();
+}
 
 const char* arduinoOtaErrorMessage(unsigned errorCode) {
     switch (errorCode) {
@@ -176,7 +222,8 @@ bool processUploadChunk(AsyncWebServerRequest* request, size_t index, uint8_t* d
         LOGF(ERROR, "OTA %s update write failed at byte %d", errorType, index + len);
         endSessionError("OTA " + errorType + " update write failed at byte " + String(index + len));
         Update.abort();
-        request->send(500, "application/json", R"({"success": false, "message": "Write failed"})");
+        setUploadResult(500, R"({"success": false, "message": "Write failed"})");
+        g_uploadRejected = true;
         return false;
     }
 
@@ -266,7 +313,12 @@ bool isActive() noexcept {
 }
 
 void runMainLoopTick() noexcept {
-    ArduinoOTA.handle();
+    // Deliberately does not call ArduinoOTA.handle(): this runs only while a
+    // session is already active. ArduinoOTA's own transfer blocks inside its
+    // handle() call, so it never needs re-entry mid-flash, and servicing it here
+    // would let an espota invitation start a second Update during an HTTP or URL
+    // update. New ArduinoOTA sessions are accepted from updateNetwork(), which
+    // only runs when no update is active.
     if (g_displayContext) {
         refreshDisplay(*g_displayContext);
     }
@@ -441,45 +493,44 @@ bool updateFilesystemFromURL(const String& url) {
 
 void handleFirmwareUpload(
     AsyncWebServerRequest* request, const String& filename, size_t index, uint8_t* data, size_t len, bool final) {
-    LOGF(INFO,
-         "handleFirmwareUpload called: filename=%s, index=%d, len=%d, final=%d",
-         filename.c_str(),
-         static_cast<int>(index),
-         static_cast<int>(len),
-         final);
-
-    if (index == 0 && !validateFileExtension(filename, false)) {
-        LOGF(ERROR, "Invalid firmware file: %s (expected .bin extension)", filename.c_str());
-        request->send(400,
-                      "application/json",
-                      R"({"success": false, "message": "Invalid firmware file. Expected .bin extension."})");
-        return;
-    }
-
     if (index == 0) {
-        if (isUpdateInProgress()) {
+        LOGF(INFO, "OTA firmware upload started: %s", filename.c_str());
+        clearUploadResult();
+        g_uploadRejected = false;
+
+        if (!validateFileExtension(filename, false)) {
+            LOGF(ERROR, "Invalid firmware file: %s (expected .bin extension)", filename.c_str());
+            setUploadResult(400, R"({"success": false, "message": "Invalid firmware file. Expected .bin extension."})");
+            g_uploadRejected = true;
+            return;
+        }
+
+        if (otaBusy()) {
             LOGF(WARNING,
                  "Rejected concurrent OTA file upload attempt (current status: %s, updateStarted: %s, "
                  "Update.isRunning(): %s)",
                  getOTAState().getUpdateStatus().c_str(),
                  getOTAState().isUpdateStarted() ? "true" : "false",
                  Update.isRunning() ? "true" : "false");
-            request->send(
+            setUploadResult(
                 409,
-                "application/json",
                 R"({"success": false, "message": "OTA update already in progress. Please wait for current update to complete."})");
+            g_uploadRejected = true;
             return;
         }
 
-        LOGF(INFO, "OTA firmware update started: %s", filename.c_str());
-
         if (!Update.begin(UPDATE_SIZE_UNKNOWN)) {
             LOGF(ERROR, "OTA update failed to begin: %s", Update.errorString());
-            request->send(500, "application/json", R"({"success": false, "message": "Failed to begin update"})");
+            setUploadResult(500, R"({"success": false, "message": "Failed to begin update"})");
+            g_uploadRejected = true;
             return;
         }
 
         beginSession(Type::Firmware);
+    }
+
+    if (g_uploadRejected) {
+        return;
     }
 
     if (!processUploadChunk(request, index, data, len, false)) {
@@ -493,64 +544,59 @@ void handleFirmwareUpload(
         if (getOTAState().isUpdateStarted() && Update.end(true)) {
             LOGF(INFO, "OTA firmware update completed successfully: %d bytes", getOTAState().getTotalSize());
             endSessionSuccess();
-            request->send(
-                200, "application/json", R"({"success": true, "message": "Update successful. Device will restart."})");
-            scheduleRestart(OTA_RESTART_DELAY_MS);
+            setUploadResult(200, R"({"success": true, "message": "Update successful. Device will restart."})");
         } else {
             LOGF(ERROR, "OTA update failed to finalize: %s", Update.errorString());
             endSessionError("OTA update failed to finalize: " + String(Update.errorString()));
-            const String errorResponse =
-                "{\"success\": false, \"message\": \"" + getOTAState().getErrorMessage() + "\"}";
-            request->send(500, "application/json", errorResponse);
+            setUploadResult(500, "{\"success\": false, \"message\": \"" + getOTAState().getErrorMessage() + "\"}");
         }
     }
 }
 
 void handleFilesystemUpload(
     AsyncWebServerRequest* request, const String& filename, size_t index, uint8_t* data, size_t len, bool final) {
-    LOGF(INFO,
-         "handleFilesystemUpload called: filename=%s, index=%d, len=%d, final=%d",
-         filename.c_str(),
-         static_cast<int>(index),
-         static_cast<int>(len),
-         final);
-
-    if (index == 0 && !validateFileExtension(filename, true)) {
-        LOGF(ERROR, "Invalid filesystem file: %s (expected .bin or .img extension)", filename.c_str());
-        request->send(400,
-                      "application/json",
-                      R"({"success": false, "message": "Invalid filesystem file. Expected .bin or .img extension."})");
-        return;
-    }
-
     if (index == 0) {
-        if (isUpdateInProgress()) {
+        LOGF(INFO, "OTA filesystem upload started: %s (partition: %s)", filename.c_str(), FILESYSTEM_PARTITION_LABEL);
+        clearUploadResult();
+        g_uploadRejected = false;
+
+        if (!validateFileExtension(filename, true)) {
+            LOGF(ERROR, "Invalid filesystem file: %s (expected .bin or .img extension)", filename.c_str());
+            setUploadResult(
+                400, R"({"success": false, "message": "Invalid filesystem file. Expected .bin or .img extension."})");
+            g_uploadRejected = true;
+            return;
+        }
+
+        if (otaBusy()) {
             LOGF(WARNING,
                  "Rejected concurrent OTA filesystem upload attempt (current status: %s, updateStarted: %s, "
                  "Update.isRunning(): %s)",
                  getOTAState().getUpdateStatus().c_str(),
                  getOTAState().isUpdateStarted() ? "true" : "false",
                  Update.isRunning() ? "true" : "false");
-            request->send(
+            setUploadResult(
                 409,
-                "application/json",
                 R"({"success": false, "message": "OTA update already in progress. Please wait for current update to complete."})");
+            g_uploadRejected = true;
             return;
         }
-
-        LOGF(INFO, "OTA filesystem update started: %s (partition: %s)", filename.c_str(), FILESYSTEM_PARTITION_LABEL);
 
         if (!Update.begin(UPDATE_SIZE_UNKNOWN, U_SPIFFS, -1, LOW, FILESYSTEM_PARTITION_LABEL)) {
             LOGF(ERROR,
                  "OTA filesystem update failed to begin on partition '%s': %s",
                  FILESYSTEM_PARTITION_LABEL,
                  Update.errorString());
-            request->send(
-                500, "application/json", R"({"success": false, "message": "Failed to begin filesystem update"})");
+            setUploadResult(500, R"({"success": false, "message": "Failed to begin filesystem update"})");
+            g_uploadRejected = true;
             return;
         }
 
         beginSession(Type::Filesystem);
+    }
+
+    if (g_uploadRejected) {
+        return;
     }
 
     if (!processUploadChunk(request, index, data, len, true)) {
@@ -567,16 +613,12 @@ void handleFilesystemUpload(
                  getOTAState().getTotalSize(),
                  FILESYSTEM_PARTITION_LABEL);
             endSessionSuccess();
-            request->send(200,
-                          "application/json",
-                          R"({"success": true, "message": "Filesystem update successful. Device will restart."})");
-            scheduleRestart(OTA_RESTART_DELAY_MS);
+            setUploadResult(200,
+                            R"({"success": true, "message": "Filesystem update successful. Device will restart."})");
         } else {
             LOGF(ERROR, "OTA filesystem update failed to finalize: %s", Update.errorString());
             endSessionError("OTA filesystem update failed to finalize: " + String(Update.errorString()));
-            const String errorResponse =
-                "{\"success\": false, \"message\": \"" + getOTAState().getErrorMessage() + "\"}";
-            request->send(500, "application/json", errorResponse);
+            setUploadResult(500, "{\"success\": false, \"message\": \"" + getOTAState().getErrorMessage() + "\"}");
         }
     }
 }
@@ -599,7 +641,7 @@ void handleURLUpdate(AsyncWebServerRequest* request) {
         return;
     }
 
-    if (isUpdateInProgress()) {
+    if (otaBusy()) {
         LOGF(WARNING,
              "Rejected concurrent OTA URL update attempt (current status: %s, updateStarted: %s, Update.isRunning(): "
              "%s)",
@@ -613,27 +655,71 @@ void handleURLUpdate(AsyncWebServerRequest* request) {
         return;
     }
 
-    LOGF(INFO, "Starting OTA update from URL: %s (type: %s)", updateUrl.c_str(), updateTypeParam.c_str());
+    // The download blocks for many seconds. Running it here would stall the
+    // AsyncTCP task and the response would never reach the client, so queue it
+    // for the main loop and answer immediately. Progress is available via
+    // /api/ota/status.
+    g_pendingUrl             = updateUrl;
+    g_pendingUrlIsFilesystem = (updateTypeParam == Type::Filesystem);
+    g_pendingUrlStartAtMs    = millis() + URL_UPDATE_START_DELAY_MS;
+    g_pendingUrlQueued       = true;
 
-    const bool isFilesystem = updateTypeParam == Type::Filesystem;
+    // Make the queue window visible to /api/ota/status instead of reporting
+    // "idle" until the download actually starts.
+    getOTAState().setUpdateType(g_pendingUrlIsFilesystem ? Type::Filesystem : Type::Firmware);
+    getOTAState().setUpdateStatus(Status::Queued);
+
+    LOGF(INFO, "Queued OTA update from URL: %s (type: %s)", updateUrl.c_str(), updateTypeParam.c_str());
+
+    request->send(202,
+                  "application/json",
+                  R"({"success": true, "message": "Update started. Poll /api/ota/status for progress."})");
+}
+
+void pollPendingUrlUpdate() noexcept {
+    if (!g_pendingUrlQueued) {
+        return;
+    }
+    // Give AsyncTCP a moment to flush the queued HTTP response before the
+    // blocking download starves it.
+    if (static_cast<long>(millis() - g_pendingUrlStartAtMs) < 0) {
+        return;
+    }
+
+    // An upload may have started during the start delay. Never begin a second
+    // flash on top of a running one. Checked before the queue flag is released
+    // so there is no window where neither the flag nor the session marks the
+    // device as busy. flashInProgress() is the right test here: isActive() would
+    // also match this request's own "queued" status.
+    if (flashInProgress()) {
+        LOG(WARNING, "Dropping queued OTA URL update - another update is already in progress");
+        g_pendingUrlQueued = false;
+        g_pendingUrl       = String();
+        getOTAState().setUpdateError(true, "Queued URL update dropped: another update was already in progress");
+        return;
+    }
+
+    const String url          = g_pendingUrl;
+    const bool   isFilesystem = g_pendingUrlIsFilesystem;
+
+    LOGF(INFO, "Starting queued OTA update from URL: %s", url.c_str());
+
+    // Claim the session first, then release the queue slot: beginSession() marks
+    // the update in progress, so otaBusy() stays true across the handover.
     beginSession(isFilesystem ? Type::Filesystem : Type::Firmware);
     getOTAState().setUpdateStatus(Status::Downloading);
+    g_pendingUrlQueued = false;
+    g_pendingUrl       = String();
 
-    const bool success = isFilesystem ? updateFilesystemFromURL(updateUrl) : updateFromURL(updateUrl);
+    const bool success = isFilesystem ? updateFilesystemFromURL(url) : updateFromURL(url);
 
     if (success) {
         endSessionSuccess();
-        request->send(
-            200, "application/json", R"({"success": true, "message": "Update successful. Device will restart."})");
         scheduleRestart(OTA_RESTART_DELAY_MS);
+    } else if (getOTAState().hasUpdateError()) {
+        endSessionError(getOTAState().getErrorMessage());
     } else {
-        if (!getOTAState().hasUpdateError()) {
-            endSessionError("OTA URL update failed");
-        } else {
-            endSessionError(getOTAState().getErrorMessage());
-        }
-        const String response = "{\"success\": false, \"message\": \"" + getOTAState().getErrorMessage() + "\"}";
-        request->send(500, "application/json", response);
+        endSessionError("OTA URL update failed");
     }
 }
 
@@ -732,25 +818,45 @@ bool shouldShowOtaDisplay() noexcept {
     return false;
 }
 
+namespace {
+
+/// Answers an upload request once the whole body has been parsed. The upload
+/// callback records its outcome in g_uploadHttpCode/g_uploadHttpBody; a code of
+/// 0 means no upload data ever arrived.
+void sendUploadResult(AsyncWebServerRequest* request, const char* missingFileMessage) {
+    const int code = g_uploadHttpCode;
+
+    if (code == 0) {
+        LOGF(ERROR, "%s", missingFileMessage);
+        request->send(
+            400, "application/json", String(R"({"success": false, "message": ")") + missingFileMessage + R"("})");
+        return;
+    }
+
+    request->send(code, "application/json", g_uploadHttpBody);
+    clearUploadResult();
+
+    // Restart only after the response has been handed to the client.
+    if (code == 200) {
+        scheduleRestart(OTA_RESTART_DELAY_MS);
+    }
+}
+
+} // namespace
+
 void setup(AsyncWebServer& server) {
     LOGF(INFO, "Setting up OTA endpoints");
 
     server.on(
         "/api/ota/firmware",
         HTTP_POST,
-        [](AsyncWebServerRequest* request) {
-            LOGF(ERROR, "OTA firmware upload request received without file data");
-            request->send(400, "application/json", R"({"success": false, "message": "No firmware file provided"})");
-        },
+        [](AsyncWebServerRequest* request) { sendUploadResult(request, "No firmware file provided"); },
         handleFirmwareUpload);
 
     server.on(
         "/api/ota/filesystem",
         HTTP_POST,
-        [](AsyncWebServerRequest* request) {
-            LOGF(ERROR, "OTA filesystem upload request received without file data");
-            request->send(400, "application/json", R"({"success": false, "message": "No filesystem file provided"})");
-        },
+        [](AsyncWebServerRequest* request) { sendUploadResult(request, "No filesystem file provided"); },
         handleFilesystemUpload);
 
     server.on("/api/ota/url", HTTP_POST, handleURLUpdate);

--- a/test/esp_task_wdt.h
+++ b/test/esp_task_wdt.h
@@ -63,3 +63,17 @@ inline esp_err_t esp_task_wdt_delete(void* task_handle) {
 inline esp_err_t esp_task_wdt_deinit() {
     return ESP_OK;
 }
+
+
+/**
+ * @brief Subscribe the Arduino loop task to the watchdog timer
+ *
+ * Provided by esp32-hal-misc.c on hardware; stubbed here because native tests
+ * compile with -DESP32.
+ */
+inline void enableLoopWDT() {}
+
+/**
+ * @brief Unsubscribe the Arduino loop task from the watchdog timer
+ */
+inline void disableLoopWDT() {}


### PR DESCRIPTION
## Summary

OTA was broken on all three update paths. Root cause of the espota failure was the Task Watchdog rebooting the device mid-flash; the HTTP and URL paths had three further independent bugs that made them unusable even though the flash itself succeeded.

Debugged against real hardware (`10.0.1.167`, ESP32 + USB serial).

## Root cause: watchdog reboot mid-flash

`Watchdog::begin()` subscribed the loop task with a raw `esp_task_wdt_add()`, bypassing the Arduino core's `loopTaskWDTEnabled` bookkeeping. `CleverCoffeeWiFiManager` toggles the loop WDT through that same core helper, so its `enableLoopWDT()` re-subscribed the task behind `Watchdog`'s back. The following `resume()` then failed to add an already-subscribed task and left `suspended_` stuck `true`.

From then on `suspend()` was a no-op, so the watchdog stayed armed while ArduinoOTA blocks `loop()` for the entire transfer. The core only resets the TWDT once per loop iteration, so nothing fed it — panic ~5s in, reboot mid-flash. espota reported this as `OTA_RECEIVE_ERROR` at ~18%.

Fix: route `begin`/`suspend`/`resume` through `enableLoopWDT`/`disableLoopWDT` so both owners share one source of truth, and make `suspend()` idempotent.

## HTTP path (`/api/ota/firmware`, used by the web UI)

- **Always returned 400.** The request callback runs *after* the body is parsed, and `request->send()` replaces any existing response — its unconditional error overwrote the `200` set by the upload callback. Upload callbacks now record an outcome; the request callback sends it.
- **Never rebooted.** `pollPendingRestart()` ran only while `OTA::isActive()`, which goes false the moment the session ends.

## URL path (`/api/ota/url`)

- **Returned nothing at all.** It downloaded synchronously inside the async handler, starving AsyncTCP so the response never reached the client. Now answers `202` immediately and downloads from the main loop, with a `queued` status and live progress via `/api/ota/status`.

## Concurrency

Requests are gated on `otaBusy()`, which also covers a queued-but-not-yet-started URL update — without it an upload could begin a second flash during the start delay. `pollPendingUrlUpdate()` claims the session *before* releasing the queue slot so the device is never briefly unguarded, and uses `flashInProgress()` rather than `isActive()` so it doesn't mistake its own `queued` state for a competing update.

ArduinoOTA is no longer serviced from `runMainLoopTick()`: its transfer blocks inside its own `handle()` call and never needs re-entry, so polling it during an HTTP/URL update could only let espota start a competing `Update`.

## Verification

All checks run on hardware, on the final commit:

| Check | Result |
|---|---|
| `pio run -e esp32_ota -t upload` | Success, **0** watchdog triggers, reboots |
| `POST /api/ota/firmware` | `200` + auto-reboot |
| `POST /api/ota/url` | `202` → `queued` → `downloading` 28/59/90% → reboot → `idle` |
| Race: URL queued + concurrent upload | `409`, no dual flash, URL update completes |
| Errors: no file / bad ext / fs bad ext | Correct `400`s, status stays `idle` |

- `pio run --target format -e esp32_usb` — clean
- `pio run -e esp32_usb` — builds
- `pio test -e native_test` — **340/340 pass**
- First commit verified independently buildable + green in a separate worktree (bisectable)

## Notes for reviewers

- Native tests compile with `-DESP32` but without the Arduino HAL, so `enableLoopWDT`/`disableLoopWDT` are stubbed in `test/esp_task_wdt.h`. Without this, 6 unrelated suites fail to compile — worth knowing for future HAL-adjacent changes.
- The URL download blocks `loop()` (PID/sensors paused). This matches existing ArduinoOTA behaviour, and `prepareHardware()` disables the heater and timer1 first, so the machine sits in a safe idle state.
- The drop path sets status `error` after the client already received its `202`. Intentional — surfacing it via status is the only channel left.
- **No unit tests for these paths.** The handlers depend on `Update`, `AsyncWebServerRequest` and the TWDT, none of which are stubbed, so `docs/integration-tests.md` is the real gate. Adding those stubs is a reasonable follow-up.
